### PR TITLE
Ease addition of modules

### DIFF
--- a/src/main/java/com/mercari/solution/config/Config.java
+++ b/src/main/java/com/mercari/solution/config/Config.java
@@ -1,6 +1,7 @@
 package com.mercari.solution.config;
 
 import com.google.gson.*;
+import com.mercari.solution.module.transform.BeamSQLTransform;
 import com.mercari.solution.util.TemplateUtil;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -11,7 +12,9 @@ import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StringWriter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -79,8 +82,9 @@ public class Config implements Serializable {
         if(this.transforms == null) {
             return false;
         }
+        final String beamSQLTransformName = new BeamSQLTransform().getName();
         final Optional<TransformConfig> tc = this.transforms.stream()
-                .filter(c -> TransformConfig.Module.beamsql.equals(c.getModule()))
+                .filter(c -> beamSQLTransformName.equals(c.getModule()))
                 .findFirst();
         if(!tc.isPresent()) {
             return false;

--- a/src/main/java/com/mercari/solution/config/SinkConfig.java
+++ b/src/main/java/com/mercari/solution/config/SinkConfig.java
@@ -10,20 +10,8 @@ import java.util.List;
 
 public class SinkConfig implements Serializable {
 
-    public enum Module {
-        storage,
-        bigquery,
-        spanner,
-        bigtable,
-        datastore,
-        jdbc,
-        pubsub,
-        text,
-        solrindex
-    }
-
     private String name;
-    private Module module;
+    private String module;
     private String input;
     private List<String> wait;
     private String outputAvroSchema;
@@ -37,11 +25,11 @@ public class SinkConfig implements Serializable {
         this.name = name;
     }
 
-    public Module getModule() {
+    public String getModule() {
         return module;
     }
 
-    public void setModule(Module module) {
+    public void setModule(String module) {
         this.module = module;
     }
 

--- a/src/main/java/com/mercari/solution/config/SourceConfig.java
+++ b/src/main/java/com/mercari/solution/config/SourceConfig.java
@@ -14,18 +14,8 @@ import java.util.List;
 
 public class SourceConfig implements Serializable {
 
-    public enum Module {
-        storage,
-        bigquery,
-        spanner,
-        datastore,
-        jdbc,
-        pubsub,
-        spannerBackup
-    }
-
     private String name;
-    private Module module;
+    private String module;
     private Boolean microbatch;
     private InputSchema schema;
     private JsonObject parameters;
@@ -41,11 +31,11 @@ public class SourceConfig implements Serializable {
         this.name = name;
     }
 
-    public Module getModule() {
+    public String getModule() {
         return module;
     }
 
-    public void setModule(Module module) {
+    public void setModule(String module) {
         this.module = module;
     }
 

--- a/src/main/java/com/mercari/solution/config/TransformConfig.java
+++ b/src/main/java/com/mercari/solution/config/TransformConfig.java
@@ -4,28 +4,11 @@ import com.google.gson.JsonObject;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 
 public class TransformConfig implements Serializable {
 
-    public enum Module {
-        flatten,
-        groupby,
-        beamsql,
-        window,
-        setoperation,
-        pdfextract,
-        crypto,
-        protobuf,
-        feature,
-        javascript,
-        onnx,
-        reshuffle,
-        automl
-    }
-
     private String name;
-    private Module module;
+    private String module;
     private List<String> inputs;
     private JsonObject parameters;
     private List<String> wait;
@@ -38,11 +21,11 @@ public class TransformConfig implements Serializable {
         this.name = name;
     }
 
-    public Module getModule() {
+    public String getModule() {
         return module;
     }
 
-    public void setModule(Module module) {
+    public void setModule(String module) {
         this.module = module;
     }
 

--- a/src/main/java/com/mercari/solution/module/Module.java
+++ b/src/main/java/com/mercari/solution/module/Module.java
@@ -1,0 +1,5 @@
+package com.mercari.solution.module;
+
+public interface Module {
+    public String getName();
+}

--- a/src/main/java/com/mercari/solution/module/ModuleRegistry.java
+++ b/src/main/java/com/mercari/solution/module/ModuleRegistry.java
@@ -1,0 +1,77 @@
+package com.mercari.solution.module;
+
+import com.mercari.solution.module.sink.*;
+import com.mercari.solution.module.source.*;
+import com.mercari.solution.module.transform.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ModuleRegistry {
+    private static final ModuleRegistry instance = new ModuleRegistry();
+
+    private final Map<String, SourceModule> sources = new HashMap<>();
+    private final Map<String, TransformModule> transforms = new HashMap<>();
+    private final Map<String, SinkModule> sinks = new HashMap<>();
+
+    public static ModuleRegistry getInstance() {
+        return instance;
+    }
+
+    private ModuleRegistry() {
+        registerBuiltinModules();
+    }
+
+    private void registerBuiltinModules() {
+        registerSource(new BigQuerySource());
+        registerSource(new DatastoreSource());
+        registerSource(new JdbcSource());
+        registerSource(new PubSubSource());
+        registerSource(new SpannerBackupSource());
+        registerSource(new SpannerSource());
+        registerSource(new StorageSource());
+
+        registerTransform(new AutoMLTablesTransform());
+        registerTransform(new BeamSQLTransform());
+        registerTransform(new FeatureTransform());
+        registerTransform(new FlattenTransform());
+        registerTransform(new GroupByTransform());
+        registerTransform(new PDFExtractTransform());
+        registerTransform(new ReshuffleTransform());
+        registerTransform(new SetOperationTransform());
+        registerTransform(new WindowTransform());
+
+        registerSink(new BigQuerySink());
+        registerSink(new BigtableSink());
+        registerSink(new DatastoreSink());
+        registerSink(new JdbcSink());
+        registerSink(new SolrIndexSink());
+        registerSink(new SpannerSink());
+        registerSink(new StorageSink());
+        registerSink(new TextSink());
+    }
+
+    public void registerSource(SourceModule module) {
+        sources.put(module.getName(), module);
+    }
+
+    public void registerTransform(TransformModule module) {
+        transforms.put(module.getName(), module);
+    }
+
+    public void registerSink(SinkModule module) {
+        sinks.put(module.getName(), module);
+    }
+
+    public SourceModule getSource(String name) {
+        return sources.get(name);
+    }
+
+    public TransformModule getTransform(String name) {
+        return transforms.get(name);
+    }
+
+    public SinkModule getSink(String name) {
+        return sinks.get(name);
+    }
+}

--- a/src/main/java/com/mercari/solution/module/ModuleRegistry.java
+++ b/src/main/java/com/mercari/solution/module/ModuleRegistry.java
@@ -1,13 +1,19 @@
 package com.mercari.solution.module;
 
-import com.mercari.solution.module.sink.*;
-import com.mercari.solution.module.source.*;
-import com.mercari.solution.module.transform.*;
+import com.google.common.reflect.ClassPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ModuleRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(ModuleRegistry.class);
+
     private static final ModuleRegistry instance = new ModuleRegistry();
 
     private final Map<String, SourceModule> sources = new HashMap<>();
@@ -23,44 +29,26 @@ public class ModuleRegistry {
     }
 
     private void registerBuiltinModules() {
-        registerSource(new BigQuerySource());
-        registerSource(new DatastoreSource());
-        registerSource(new JdbcSource());
-        registerSource(new PubSubSource());
-        registerSource(new SpannerBackupSource());
-        registerSource(new SpannerSource());
-        registerSource(new StorageSource());
+        List<Class<? extends SourceModule>> sourceModules = findModulesInPackage("com.mercari.solution.module.source", SourceModule.class);
+        sourceModules.forEach(this::registerSource);
 
-        registerTransform(new AutoMLTablesTransform());
-        registerTransform(new BeamSQLTransform());
-        registerTransform(new FeatureTransform());
-        registerTransform(new FlattenTransform());
-        registerTransform(new GroupByTransform());
-        registerTransform(new PDFExtractTransform());
-        registerTransform(new ReshuffleTransform());
-        registerTransform(new SetOperationTransform());
-        registerTransform(new WindowTransform());
+        List<Class<? extends TransformModule>> transformModules = findModulesInPackage("com.mercari.solution.module.transform", TransformModule.class);
+        transformModules.forEach(this::registerTransform);
 
-        registerSink(new BigQuerySink());
-        registerSink(new BigtableSink());
-        registerSink(new DatastoreSink());
-        registerSink(new JdbcSink());
-        registerSink(new SolrIndexSink());
-        registerSink(new SpannerSink());
-        registerSink(new StorageSink());
-        registerSink(new TextSink());
+        List<Class<? extends SinkModule>> sinkModules = findModulesInPackage("com.mercari.solution.module.sink", SinkModule.class);
+        sinkModules.forEach(this::registerSink);
     }
 
-    public void registerSource(SourceModule module) {
-        sources.put(module.getName(), module);
+    public void registerSource(Class<? extends SourceModule> moduleClass) {
+        registerModule(sources, moduleClass);
     }
 
-    public void registerTransform(TransformModule module) {
-        transforms.put(module.getName(), module);
+    public void registerTransform(Class<? extends TransformModule> moduleClass) {
+        registerModule(transforms, moduleClass);
     }
 
-    public void registerSink(SinkModule module) {
-        sinks.put(module.getName(), module);
+    public void registerSink(Class<? extends SinkModule> moduleClass) {
+        registerModule(sinks, moduleClass);
     }
 
     public SourceModule getSource(String name) {
@@ -74,4 +62,36 @@ public class ModuleRegistry {
     public SinkModule getSink(String name) {
         return sinks.get(name);
     }
+
+    private <T extends Module> List<Class<? extends T>> findModulesInPackage(String packageName, Class<T> moduleClass) {
+        ClassPath classPath;
+        try {
+            ClassLoader loader = getClass().getClassLoader();
+            classPath = ClassPath.from(loader);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Reading classpath resource failed", ioe);
+        }
+        List<Class<? extends T>> modules = classPath.getTopLevelClassesRecursive(packageName)
+                .stream()
+                .map(ClassPath.ClassInfo::load)
+                .filter(moduleClass::isAssignableFrom)
+                .map(clazz -> (Class<? extends T>)clazz.asSubclass(moduleClass))
+                .collect(Collectors.toList());
+        return modules;
+    }
+
+    private <T extends Module> void registerModule(Map<String, T> container, Class<? extends T> moduleClass) {
+        T module;
+        try {
+            module = moduleClass.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new RuntimeException("Failed to instantiate module: " + moduleClass, e);
+        }
+        if (container.containsKey(module.getName())) {
+            throw new IllegalStateException("Module is already registered: " + module.getName());
+        }
+        container.put(module.getName(), module);
+        LOG.debug("registered module: " + module.getName());
+    }
+
 }

--- a/src/main/java/com/mercari/solution/module/SinkModule.java
+++ b/src/main/java/com/mercari/solution/module/SinkModule.java
@@ -1,0 +1,10 @@
+package com.mercari.solution.module;
+
+import com.mercari.solution.config.SinkConfig;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SinkModule extends Module {
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits);
+}

--- a/src/main/java/com/mercari/solution/module/SourceModule.java
+++ b/src/main/java/com/mercari/solution/module/SourceModule.java
@@ -1,0 +1,12 @@
+package com.mercari.solution.module;
+
+import com.mercari.solution.config.SourceConfig;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SourceModule extends Module {
+    public Map<String, FCollection<?>> expand(PBegin begin, SourceConfig config, PCollection<Long> beats, List<FCollection<?>> waits);
+}

--- a/src/main/java/com/mercari/solution/module/TransformModule.java
+++ b/src/main/java/com/mercari/solution/module/TransformModule.java
@@ -1,0 +1,10 @@
+package com.mercari.solution.module;
+
+import com.mercari.solution.config.TransformConfig;
+
+import java.util.List;
+import java.util.Map;
+
+public interface TransformModule extends Module {
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config);
+}

--- a/src/main/java/com/mercari/solution/module/sink/BigQuerySink.java
+++ b/src/main/java/com/mercari/solution/module/sink/BigQuerySink.java
@@ -10,6 +10,7 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.AvroSchemaUtil;
 import com.mercari.solution.util.OptionUtil;
 import com.mercari.solution.util.converter.*;
@@ -18,16 +19,20 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.*;
 import org.apache.beam.sdk.transforms.*;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
-public class BigQuerySink {
+public class BigQuerySink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
 
@@ -123,6 +128,12 @@ public class BigQuerySink {
         public void setOutputError(String outputError) {
             this.outputError = outputError;
         }
+    }
+
+    public String getName() { return "bigquery"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), BigQuerySink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/sink/BigtableSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/BigtableSink.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.protobuf.ByteString;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.OptionUtil;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import com.mercari.solution.util.converter.RowToBigtableConverter;
@@ -23,7 +24,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 
-public class BigtableSink {
+public class BigtableSink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(BigtableSink.class);
 
@@ -104,6 +105,12 @@ public class BigtableSink {
             this.exclude = exclude;
         }
 
+    }
+
+    public String getName() { return "bigtable"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), BigtableSink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/sink/DatastoreSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/DatastoreSink.java
@@ -4,23 +4,23 @@ import com.google.datastore.v1.Entity;
 import com.google.gson.Gson;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.datastore.DatastoreIO;
 import org.apache.beam.sdk.io.gcp.datastore.DatastoreV1;
-import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.Wait;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
-public class DatastoreSink {
+public class DatastoreSink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreSink.class);
 
@@ -62,6 +62,12 @@ public class DatastoreSink {
         public void setDelete(Boolean delete) {
             this.delete = delete;
         }
+    }
+
+    public String getName() { return "datastore"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), DatastoreSink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/sink/JdbcSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/JdbcSink.java
@@ -3,6 +3,7 @@ package com.mercari.solution.module.sink;
 import com.google.gson.Gson;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.converter.ToStatementConverter;
 import com.mercari.solution.util.gcp.JdbcUtil;
 import org.apache.beam.sdk.coders.ListCoder;
@@ -17,12 +18,10 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
-public class JdbcSink {
+public class JdbcSink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcSink.class);
 
@@ -127,6 +126,12 @@ public class JdbcSink {
         public void setOp(String op) {
             this.op = op;
         }
+    }
+
+    public String getName() { return "jdbc"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), JdbcSink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/sink/SolrIndexSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/SolrIndexSink.java
@@ -6,11 +6,15 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.module.sink.fileio.SolrSink;
 import com.mercari.solution.util.AvroSchemaUtil;
 import com.mercari.solution.util.FixedFileNaming;
 import com.mercari.solution.util.RowSchemaUtil;
-import com.mercari.solution.util.converter.*;
+import com.mercari.solution.util.converter.EntityToSolrDocumentConverter;
+import com.mercari.solution.util.converter.RecordToSolrDocumentConverter;
+import com.mercari.solution.util.converter.RowToSolrDocumentConverter;
+import com.mercari.solution.util.converter.StructToSolrDocumentConverter;
 import com.mercari.solution.util.gcp.DatastoreUtil;
 import com.mercari.solution.util.gcp.SpannerUtil;
 import com.mercari.solution.util.gcp.StorageUtil;
@@ -30,11 +34,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class SolrIndexSink {
+public class SolrIndexSink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(SolrIndexSink.class);
 
@@ -126,6 +132,12 @@ public class SolrIndexSink {
             this.outputSchema = outputSchema;
         }
 
+    }
+
+    public String getName() { return "solrindex"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), SolrIndexSink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/sink/SpannerSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/SpannerSink.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.OptionUtil;
 import com.mercari.solution.util.RowSchemaUtil;
 import com.mercari.solution.util.converter.DataTypeTransform;
@@ -19,7 +20,7 @@ import org.apache.beam.sdk.io.gcp.spanner.SpannerWriteResult;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.*;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.PCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +28,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class SpannerSink {
+public class SpannerSink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpannerSink.class);
 
@@ -248,6 +249,12 @@ public class SpannerSink {
         public void setPrimaryKeyFields(String primaryKeyFields) {
             this.primaryKeyFields = primaryKeyFields;
         }
+    }
+
+    public String getName() { return "spanner"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), SpannerSink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/sink/TextSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/TextSink.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.TemplateFileNaming;
 import com.mercari.solution.util.TemplateUtil;
 import com.mercari.solution.util.aws.S3Util;
@@ -32,13 +33,14 @@ import java.io.*;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 
-public class TextSink {
+public class TextSink implements SinkModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(StorageSink.class);
 
@@ -145,6 +147,12 @@ public class TextSink {
         public void setMetadata(Map<String, String> metadata) {
             this.metadata = metadata;
         }
+    }
+
+    public String getName() { return "text"; }
+
+    public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
+        return Collections.singletonMap(config.getName(), TextSink.write(input, config, waits));
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {

--- a/src/main/java/com/mercari/solution/module/source/DatastoreSource.java
+++ b/src/main/java/com/mercari/solution/module/source/DatastoreSource.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.SourceConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SourceModule;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import com.mercari.solution.util.gcp.DatastoreUtil;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
@@ -18,10 +19,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
-public class DatastoreSource {
+public class DatastoreSource implements SourceModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreSource.class);
 
@@ -80,6 +83,17 @@ public class DatastoreSource {
 
         public void setEmulator(Boolean emulator) {
             this.emulator = emulator;
+        }
+    }
+
+    public String getName() { return "datastore"; }
+
+    public Map<String, FCollection<?>> expand(PBegin begin, SourceConfig config, PCollection<Long> beats, List<FCollection<?>> waits) {
+        if (config.getMicrobatch() != null && config.getMicrobatch()) {
+            //inputs.put(config.getName(), beats.apply(config.getName(), SpannerSource.microbatch(config)));
+            return Collections.emptyMap();
+        } else {
+            return Collections.singletonMap(config.getName(), DatastoreSource.batch(begin, config));
         }
     }
 

--- a/src/main/java/com/mercari/solution/module/source/JdbcSource.java
+++ b/src/main/java/com/mercari/solution/module/source/JdbcSource.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.SourceConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SourceModule;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import com.mercari.solution.util.converter.ResultSetToRecordConverter;
 import com.mercari.solution.util.gcp.JdbcUtil;
@@ -18,10 +19,12 @@ import org.apache.beam.sdk.values.PCollection;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
-public class JdbcSource {
+public class JdbcSource implements SourceModule {
 
     private class JdbcSourceParameters implements Serializable {
 
@@ -78,6 +81,17 @@ public class JdbcSource {
 
         public void setKmsKey(String kmsKey) {
             this.kmsKey = kmsKey;
+        }
+    }
+
+    public String getName() { return "jdbc"; }
+
+    public Map<String, FCollection<?>> expand(PBegin begin, SourceConfig config, PCollection<Long> beats, List<FCollection<?>> waits) {
+        if (config.getMicrobatch() != null && config.getMicrobatch()) {
+            //inputs.put(config.getName(), beats.apply(config.getName(), SpannerSource.microbatch(config)));
+            return Collections.emptyMap();
+        } else {
+            return Collections.singletonMap(config.getName(), JdbcSource.batch(begin, config));
         }
     }
 

--- a/src/main/java/com/mercari/solution/module/source/StorageSource.java
+++ b/src/main/java/com/mercari/solution/module/source/StorageSource.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.SourceConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.SourceModule;
 import com.mercari.solution.util.AvroSchemaUtil;
 import com.mercari.solution.util.aws.S3Util;
 import com.mercari.solution.util.converter.*;
@@ -18,15 +19,16 @@ import org.apache.beam.sdk.io.parquet.ParquetIO;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.*;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
-public class StorageSource {
+public class StorageSource implements SourceModule {
 
     private class StorageSourceParameters implements Serializable {
 
@@ -74,6 +76,17 @@ public class StorageSource {
 
         public void setTargetFormat(String targetFormat) {
             this.targetFormat = targetFormat;
+        }
+    }
+
+    public String getName() { return "storage"; }
+
+    public Map<String, FCollection<?>> expand(PBegin begin, SourceConfig config, PCollection<Long> beats, List<FCollection<?>> waits) {
+        if (config.getMicrobatch() != null && config.getMicrobatch()) {
+            //inputs.put(config.getName(), beats.apply(config.getName(), StorageSource.microbatch(config)));
+            return Collections.emptyMap();
+        } else {
+            return Collections.singletonMap(config.getName(), StorageSource.batch(begin, config));
         }
     }
 

--- a/src/main/java/com/mercari/solution/module/transform/AutoMLTablesTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/AutoMLTablesTransform.java
@@ -6,9 +6,10 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.mercari.solution.config.TransformConfig;
+import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.RowSchemaUtil;
 import com.mercari.solution.util.converter.RowToAutoMLRowConverter;
-//import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -21,11 +22,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
-public class AutoMLTablesTransform {
+public class AutoMLTablesTransform implements TransformModule {
 
     private class AutoMLTablesTransformParameters {
 
@@ -56,6 +59,16 @@ public class AutoMLTablesTransform {
         public void setModelId(String modelId) {
             this.modelId = modelId;
         }
+    }
+
+    public String getName() { return "automl"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        if(config.getInputs().size() != 1) {
+            throw new IllegalArgumentException("module mlengine must not be multi input !");
+        }
+        //rows.put(transformName, rows.get(config.getInputs().get(0)).apply(AutoMLTablesTransform.process(config)));
+        return Collections.emptyMap();
     }
 
     public static AutoMLPredictProcess process(final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/BeamSQLTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/BeamSQLTransform.java
@@ -5,20 +5,25 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import com.mercari.solution.util.gcp.StorageUtil;
 import com.mercari.solution.util.sql.udf.JsonFunctions;
 import org.apache.beam.sdk.extensions.sql.SqlTransform;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TupleTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class BeamSQLTransform {
+public class BeamSQLTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(BeamSQLTransform.class);
 
@@ -33,6 +38,12 @@ public class BeamSQLTransform {
         public void setSql(String sql) {
             this.sql = sql;
         }
+    }
+
+    public String getName() { return "beamsql"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return Collections.singletonMap(config.getName(), BeamSQLTransform.transform(inputs, config));
     }
 
     public static FCollection<Row> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/CryptoTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/CryptoTransform.java
@@ -10,6 +10,7 @@ import com.google.protobuf.ByteString;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.*;
 import com.mercari.solution.util.converter.JsonToMapConverter;
 import com.mercari.solution.util.gcp.DatastoreUtil;
@@ -31,7 +32,7 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.*;
 
-public class CryptoTransform {
+public class CryptoTransform implements TransformModule {
 
 
     private static final Logger LOG = LoggerFactory.getLogger(CryptoTransform.class);
@@ -249,6 +250,12 @@ public class CryptoTransform {
             }
         }
 
+    }
+
+    public String getName() { return "crypto"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return CryptoTransform.transform(inputs, config);
     }
 
     public static Map<String, FCollection<?>> transform(

--- a/src/main/java/com/mercari/solution/module/transform/FeatureTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/FeatureTransform.java
@@ -7,13 +7,17 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.AvroSchemaUtil;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import com.mercari.solution.util.converter.RecordToFeatureRecordConverter;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.AvroCoder;
-import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 
@@ -21,11 +25,11 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class FeatureTransform {
+public class FeatureTransform implements TransformModule {
 
     private class FeatureTransformParameters {
 
@@ -38,6 +42,12 @@ public class FeatureTransform {
         public void setSql(String sql) {
             this.sql = sql;
         }
+    }
+
+    public String getName() { return "feature"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return Collections.singletonMap(config.getName(), FeatureTransform.transform(inputs, config));
     }
 
     public static FCollection<GenericRecord> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/FlattenTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/FlattenTransform.java
@@ -6,17 +6,23 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-public class FlattenTransform {
+public class FlattenTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlattenTransform.class);
 
@@ -31,6 +37,12 @@ public class FlattenTransform {
         public void setDataType(String dataType) {
             this.dataType = dataType;
         }
+    }
+
+    public String getName() { return "flatten"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return Collections.singletonMap(config.getName(), FlattenTransform.transform(inputs, config));
     }
 
     public static FCollection<?> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/GroupByTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/GroupByTransform.java
@@ -5,8 +5,9 @@ import com.google.gson.Gson;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.AvroSchemaUtil;
-import com.mercari.solution.util.converter.*;
+import com.mercari.solution.util.converter.DataTypeTransform;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
@@ -18,14 +19,17 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGroupByKey;
 import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class GroupByTransform {
+public class GroupByTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupByTransform.class);
 
@@ -41,6 +45,12 @@ public class GroupByTransform {
             this.keys = keys;
         }
 
+    }
+
+    public String getName() { return "groupby"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return Collections.singletonMap(config.getName(), GroupByTransform.transform(inputs, config));
     }
 
     public static FCollection<GenericRecord> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/PDFExtractTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/PDFExtractTransform.java
@@ -9,6 +9,7 @@ import com.google.protobuf.NullValue;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.AvroSchemaUtil;
 import com.mercari.solution.util.RowSchemaUtil;
 import com.mercari.solution.util.gcp.DatastoreUtil;
@@ -36,7 +37,7 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.*;
 
-public class PDFExtractTransform {
+public class PDFExtractTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDFExtractTransform.class);
 
@@ -73,6 +74,12 @@ public class PDFExtractTransform {
         public void setPrefix(String prefix) {
             this.prefix = prefix;
         }
+    }
+
+    public String getName() { return "pdfextract"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return PDFExtractTransform.transform(inputs, config);
     }
 
     public static Map<String, FCollection<?>> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/ProtobufTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/ProtobufTransform.java
@@ -10,6 +10,7 @@ import com.google.protobuf.util.JsonFormat;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.AvroSchemaUtil;
 import com.mercari.solution.util.ProtoUtil;
 import com.mercari.solution.util.RowSchemaUtil;
@@ -35,7 +36,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class ProtobufTransform {
+public class ProtobufTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProtobufTransform.class);
     private static final String OUTPUT_SUFFIX_FAILURES = ".failures";
@@ -101,6 +102,12 @@ public class ProtobufTransform {
             }
         }
 
+    }
+
+    public String getName() { return "protobuf"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return ProtobufTransform.transform(inputs, config);
     }
 
     public static Map<String, FCollection<?>> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/ReshuffleTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/ReshuffleTransform.java
@@ -2,6 +2,7 @@ package com.mercari.solution.module.transform;
 
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.Reshuffle;
@@ -13,9 +14,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ReshuffleTransform {
+public class ReshuffleTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReshuffleTransform.class);
+
+    public String getName() { return "reshuffle"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return ReshuffleTransform.transform(inputs, config);
+    }
 
     public static Map<String, FCollection<?>> transform(final List<FCollection<?>> inputs, final TransformConfig config) {
 

--- a/src/main/java/com/mercari/solution/module/transform/SetOperationTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/SetOperationTransform.java
@@ -4,6 +4,7 @@ import com.google.common.base.Functions;
 import com.google.gson.Gson;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import com.mercari.solution.util.converter.DataTypeTransform;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class SetOperationTransform {
+public class SetOperationTransform implements TransformModule {
 
     private class SetOperationTransformParameters {
 
@@ -42,6 +43,12 @@ public class SetOperationTransform {
             this.keys = keys;
         }
 
+    }
+
+    public String getName() { return "setoperation"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return SetOperationTransform.transform(inputs, config);
     }
 
     public static Map<String, FCollection<?>> transform(final List<FCollection<?>> inputs, final TransformConfig config) {

--- a/src/main/java/com/mercari/solution/module/transform/WindowTransform.java
+++ b/src/main/java/com/mercari/solution/module/transform/WindowTransform.java
@@ -3,6 +3,7 @@ package com.mercari.solution.module.transform;
 import com.google.gson.Gson;
 import com.mercari.solution.config.TransformConfig;
 import com.mercari.solution.module.FCollection;
+import com.mercari.solution.module.TransformModule;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.*;
@@ -16,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class WindowTransform {
+public class WindowTransform implements TransformModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowTransform.class);
 
@@ -151,6 +152,12 @@ public class WindowTransform {
         week,
         month,
         year
+    }
+
+    public String getName() { return "window"; }
+
+    public Map<String, FCollection<?>> expand(List<FCollection<?>> inputs, TransformConfig config) {
+        return WindowTransform.transform(inputs, config);
     }
 
     public static Map<String, FCollection<?>> transform(final List<FCollection<?>> inputs, final TransformConfig config) {


### PR DESCRIPTION
Currently, when we want to add a new module, we need to modify several files.
It would be preferable if just adding one file is enough.
Making it easy to add modules also has the benefit of lowering the hurdle of contribution.
This PR does two things.
1. Establish module interfaces to commonize module handling
2. discover built-in modules using reflection and register them automatically
