### PR TITLE
Support template for external sql file

### DIFF
--- a/docs/config/module/sink/storage.md
+++ b/docs/config/module/sink/storage.md
@@ -24,6 +24,8 @@ Sink module to write the input data to a specified file storage path.
 | dynamicSplitField | optional | String | If you specify a field name, for each value, the records will be output in a separate path. If specified, its value will be the output terminal Prefix. |
 | withoutSharding | optional | Boolean | Specifies whether to combine the output files into one. Default is false. |
 | tempDirectory | optional | String | The GCS path of the temporary file export destination. If not specified, the bucket creation permission is required. |
+| outputNotify | optional | String | Specify the GCS path if you want to also write out a list of destination file paths after the writing is finished. Even if the number of writes is zero, an empty file will be created. |
+| outputEmpty | optional | Boolean | Specifies whether to output an empty file even if there are no write records. Default is false. |
 | datetimeFormat | optional | String | Format of the time in the name of the export file if Window is specified. (Specify yyyyMMdd, etc.) |
 | datetimeFormatZone | optional | String | TimeZone of the time in the name of the export file if you specify a Window (default is `Etc/GMT`). |
 | useOnlyEndDatetime | optional | Boolean | If you want to use only the closing time of the window in the time of the export file name with the Window specified, specify it. (The default is `false`.)|

--- a/docs/config/module/source/bigquery.md
+++ b/docs/config/module/source/bigquery.md
@@ -16,7 +16,7 @@ Source Module for loading data by specifying a query or table into BigQuery.
 
 | parameter | optional | type | description |
 | --- | --- | --- | --- |
-| query | selective required | String | Specify the SQL to read data from BigQuery; unnecessary if table is specified |
+| query | selective required | String | Specify the SQL to read data from BigQuery. unnecessary if table is specified. You can also specify the path of the GCS where you put the SQL file. |
 | table | selective required | String | Specify a Table to load data from BigQuery ({project}. {dataset}. {table} format). If query is specified, it is not necessary. (You can't specify it in the case of view.) |
 | queryTempDataset | optional | String | Optional when specifying a query. Specify a temporary Dataset to store the query results in. If not specified, a temporary Dataset will be created. |
 | queryLocation | optional | String | Optional when specifying a query. Query execution location(ex: US) specification. |

--- a/docs/config/module/source/pubsub.md
+++ b/docs/config/module/source/pubsub.md
@@ -11,7 +11,7 @@ Source Module for loading data by specifying a gql into Cloud PubSub.
 | schema | required | [Schema](SCHEMA.md) | Schema of the data to be read |
 | parameters | required | Map<String,Object\> | Specify the following individual parameters |
 
-## BigQuery source module parameters
+## PubSub source module parameters
 
 | parameter | optional | type | description |
 | --- | --- | --- | --- |

--- a/docs/config/module/source/spanner.md
+++ b/docs/config/module/source/spanner.md
@@ -19,8 +19,8 @@ Source Module for loading data by specifying a query or table into Cloud Spanner
 | projectId | required | String | The GCP Project ID of the Spanner you want to load |
 | instanceId | required | String | The Instance ID of the Spanner you want to load |
 | databaseId | required | String | The Database ID of the Spanner you want to load |
-| query | selective required | String | Specify the SQL to read data from Spanner; not necessary if table is specified. |
-| table | selective required | String | Specify the table name to read data from Spanner; not necessary if query is specified. |
+| query | selective required | String | Specify the SQL to read data from Spanner. Not necessary if table is specified. You can also specify the path of the GCS where you put the SQL file. |
+| table | selective required | String | Specify the table name to read data from Spanner. Not necessary if query is specified. |
 | fields | optional | Array<String\> | Specify the name of the field you want to read from the table. The default is all fields. |
 | timestampBound | optional | String | Specify when you want to read the data at the specified time. Format: `yyyy-MM-ddTHH:mm:SSZ` |
 

--- a/docs/config/module/transform/beamsql.md
+++ b/docs/config/module/transform/beamsql.md
@@ -15,7 +15,7 @@ Transform Modules for processing and combining input data with a given SQL.
 
 | parameter | optional | type | description |
 | --- | --- | --- | --- |
-| sql | required |  String | sql text to process inputs data. |
+| sql | required |  String | sql text to process inputs data. You can also specify the path of the GCS where you put the SQL file. |
 
 ## Related example config files
 

--- a/src/main/java/com/mercari/solution/FlexPipeline.java
+++ b/src/main/java/com/mercari/solution/FlexPipeline.java
@@ -22,6 +22,7 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -167,7 +168,7 @@ public class FlexPipeline {
         if(configParam.startsWith("gs://")) {
             jsonText = StorageUtil.readString(configParam);
         } else if(Files.exists(Paths.get(configParam)) && !Files.isDirectory(Paths.get(configParam))) {
-            jsonText = new String(Files.readAllBytes(Paths.get(configParam)));
+            jsonText = Files.readString(Paths.get(configParam), StandardCharsets.UTF_8);
         } else {
             jsonText = configParam;
         }

--- a/src/main/java/com/mercari/solution/config/SourceConfig.java
+++ b/src/main/java/com/mercari/solution/config/SourceConfig.java
@@ -11,9 +11,11 @@ import org.apache.beam.sdk.schemas.Schema;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class SourceConfig implements Serializable {
 
+    // source module properties
     private String name;
     private String module;
     private Boolean microbatch;
@@ -23,6 +25,10 @@ public class SourceConfig implements Serializable {
     private String timestampAttribute;
     private String timestampDefault;
 
+    // template args
+    private Map<String, Object> args;
+
+    // getter, setter
     public String getName() {
         return name;
     }
@@ -88,6 +94,14 @@ public class SourceConfig implements Serializable {
 
     public void setTimestampDefault(String timestampDefault) {
         this.timestampDefault = timestampDefault;
+    }
+
+    public Map<String, Object> getArgs() {
+        return args;
+    }
+
+    public void setArgs(Map<String, Object> args) {
+        this.args = args;
     }
 
     public static Schema convertSchema(final InputSchema inputSchema) {

--- a/src/main/java/com/mercari/solution/config/TransformConfig.java
+++ b/src/main/java/com/mercari/solution/config/TransformConfig.java
@@ -4,15 +4,21 @@ import com.google.gson.JsonObject;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 public class TransformConfig implements Serializable {
 
+    // transform module properties
     private String name;
     private String module;
     private List<String> inputs;
     private JsonObject parameters;
     private List<String> wait;
 
+    // template args
+    private Map<String, Object> args;
+
+    // getter, setter
     public String getName() {
         return name;
     }
@@ -51,6 +57,14 @@ public class TransformConfig implements Serializable {
 
     public void setWait(List<String> wait) {
         this.wait = wait;
+    }
+
+    public Map<String, Object> getArgs() {
+        return args;
+    }
+
+    public void setArgs(Map<String, Object> args) {
+        this.args = args;
     }
 
 }

--- a/src/main/java/com/mercari/solution/module/source/BigQuerySource.java
+++ b/src/main/java/com/mercari/solution/module/source/BigQuerySource.java
@@ -11,6 +11,7 @@ import com.mercari.solution.config.SourceConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
 import com.mercari.solution.module.SourceModule;
+import com.mercari.solution.util.TemplateUtil;
 import com.mercari.solution.util.schema.AvroSchemaUtil;
 import com.mercari.solution.util.OptionUtil;
 import com.mercari.solution.util.converter.DataTypeTransform;
@@ -220,6 +221,7 @@ public class BigQuerySource implements SourceModule {
         private final String timestampAttribute;
         private final String timestampDefault;
         private final BigQuerySourceParameters parameters;
+        private final Map<String, Object> templateArgs;
 
         public BigQuerySourceParameters getParameters() {
             return parameters;
@@ -229,6 +231,7 @@ public class BigQuerySource implements SourceModule {
             this.timestampAttribute = config.getTimestampAttribute();
             this.timestampDefault = config.getTimestampDefault();
             this.parameters = new Gson().fromJson(config.getParameters(), BigQuerySourceParameters.class);
+            this.templateArgs = config.getArgs();
         }
 
         @Override
@@ -242,7 +245,8 @@ public class BigQuerySource implements SourceModule {
             if(parameters.getQuery() != null) {
                 final String query;
                 if(parameters.getQuery().startsWith("gs://")) {
-                    query = StorageUtil.readString(parameters.getQuery());
+                    final String rawQuery = StorageUtil.readString(parameters.getQuery());
+                    query = TemplateUtil.executeStrictTemplate(rawQuery, templateArgs);
                 } else {
                     query = parameters.getQuery();
                 }

--- a/src/main/java/com/mercari/solution/util/gcp/StorageUtil.java
+++ b/src/main/java/com/mercari/solution/util/gcp/StorageUtil.java
@@ -29,6 +29,7 @@ import org.apache.parquet.io.SeekableInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -126,7 +127,7 @@ public class StorageUtil {
 
     private static String readString(final String bucket, final String object) {
         final byte[] bytes = readBytes(bucket, object);
-        return new String(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private static byte[] readBytes(final String bucket, final String object) {

--- a/src/test/java/com/mercari/solution/config/ConfigTest.java
+++ b/src/test/java/com/mercari/solution/config/ConfigTest.java
@@ -1,0 +1,149 @@
+package com.mercari.solution.config;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mercari.solution.util.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+
+public class ConfigTest {
+
+    @Test
+    public void testGetTemplateArgs() {
+        final String[] args = {
+                "template.startDate=2021-01-01",
+                "template.create=false",
+                "template.array1=[1,2,3]",
+                "template.array2=['a','b','c']",
+                "SpannerInput.projectId=ohmyproject",
+                "SpannerInput.table=ohmytable",
+                "SpannerOutput.instanceId=ohmyinstance",
+        };
+
+        final Map<String, Object> parameters = Config.getTemplateArgs(args);
+        Assert.assertEquals(4, parameters.size());
+        Assert.assertEquals("2021-01-01", parameters.get("startDate"));
+        Assert.assertEquals(false, parameters.get("create"));
+        Assert.assertEquals(Arrays.asList(1L,2L,3L), parameters.get("array1"));
+        Assert.assertEquals(Arrays.asList("a","b","c"), parameters.get("array2"));
+    }
+
+    @Test
+    public void testConfigBeamSQL() throws Exception {
+
+        final String templateFilePath = "config/beamsql-join-bigquery-and-spanner-to-spanner.json";
+        final String configJson = ResourceUtil.getResourceFileAsString(templateFilePath);
+        final String[] args = {
+                "template.startDate=2021-01-01",
+                "template.create=false",
+                "template.keyFields=['Field1','Field2']",
+                "SpannerInput.projectId=ohmyproject",
+                "SpannerInput.table=ohmytable",
+                "SpannerOutput.instanceId=ohmyinstance"
+        };
+        final Config config = Config.parse(configJson, args);
+
+        Assert.assertEquals(2, config.getSources().size());
+        Assert.assertEquals(1, config.getTransforms().size());
+        Assert.assertEquals(1, config.getSinks().size());
+
+        // Source BigQuery
+        final SourceConfig inputBigqueryConfig = config.getSources().stream()
+                .filter(s -> s.getName().equals("BigQueryInput"))
+                .findAny()
+                .orElseThrow();
+        Assert.assertEquals(3, inputBigqueryConfig.getArgs().size());
+        Assert.assertEquals("2021-01-01", inputBigqueryConfig.getArgs().get("startDate"));
+        Assert.assertEquals(false, inputBigqueryConfig.getArgs().get("create"));
+        Assert.assertEquals(Arrays.asList("Field1","Field2"), inputBigqueryConfig.getArgs().get("keyFields"));
+
+        final JsonObject inputBigQueryParameters = inputBigqueryConfig.getParameters();
+        Assert.assertTrue(inputBigQueryParameters.has("query"));
+        Assert.assertEquals(
+                "SELECT BField1, BField2 FROM `myproject.mydataset.mytable` WHERE StartDate > DATE('2021-01-01')",
+                inputBigQueryParameters.get("query").getAsString());
+
+        // Source Spanner
+        final SourceConfig inputSpannerConfig = config.getSources().stream()
+                .filter(s -> s.getName().equals("SpannerInput"))
+                .findAny()
+                .orElseThrow();
+        Assert.assertEquals(3, inputSpannerConfig.getArgs().size());
+        Assert.assertEquals("2021-01-01", inputSpannerConfig.getArgs().get("startDate"));
+        Assert.assertEquals(false, inputSpannerConfig.getArgs().get("create"));
+        Assert.assertEquals(Arrays.asList("Field1","Field2"), inputBigqueryConfig.getArgs().get("keyFields"));
+
+        final JsonObject inputSpannerParameters = inputSpannerConfig.getParameters();
+        Assert.assertTrue(inputSpannerParameters.has("projectId"));
+        Assert.assertTrue(inputSpannerParameters.has("instanceId"));
+        Assert.assertTrue(inputSpannerParameters.has("databaseId"));
+        Assert.assertTrue(inputSpannerParameters.has("table"));
+        Assert.assertEquals(
+                "ohmyproject",
+                inputSpannerParameters.get("projectId").getAsString());
+        Assert.assertEquals(
+                "myinstance",
+                inputSpannerParameters.get("instanceId").getAsString());
+        Assert.assertEquals(
+                "mydatabase",
+                inputSpannerParameters.get("databaseId").getAsString());
+        Assert.assertEquals(
+                "ohmytable",
+                inputSpannerParameters.get("table").getAsString());
+
+        // Transform BeamSQL
+        final TransformConfig beamsqlConfig = config.getTransforms().stream()
+                .filter(s -> s.getName().equals("beamsql"))
+                .findAny()
+                .orElseThrow();
+        Assert.assertEquals(3, inputSpannerConfig.getArgs().size());
+        Assert.assertEquals("2021-01-01", inputSpannerConfig.getArgs().get("startDate"));
+        Assert.assertEquals(false, inputSpannerConfig.getArgs().get("create"));
+        Assert.assertEquals(Arrays.asList("Field1","Field2"), inputBigqueryConfig.getArgs().get("keyFields"));
+
+        final JsonObject beamsqlParameters = beamsqlConfig.getParameters();
+        Assert.assertEquals(
+                "SELECT BigQueryInput.BField1 AS Field1, IF(BigQueryInput.BField2 IS NULL, SpannerInput.SField2, BigQueryInput.BField2) AS Field2 FROM BigQueryInput LEFT JOIN SpannerInput ON BigQueryInput.BField1 = SpannerInput.SField1 WHERE BigQueryInput.Date = DATE('2021-01-01')",
+                beamsqlParameters.get("sql").getAsString());
+
+        // Sink Spanner
+        final JsonObject outputSpannerParameters = config.getSinks().stream()
+                .filter(s -> s.getName().equals("SpannerOutput"))
+                .findAny()
+                .orElseThrow()
+                .getParameters();
+
+        Assert.assertTrue(outputSpannerParameters.has("projectId"));
+        Assert.assertTrue(outputSpannerParameters.has("instanceId"));
+        Assert.assertTrue(outputSpannerParameters.has("databaseId"));
+        Assert.assertTrue(outputSpannerParameters.has("table"));
+        Assert.assertTrue(outputSpannerParameters.has("createTable"));
+        Assert.assertEquals(
+                "anotherproject",
+                outputSpannerParameters.get("projectId").getAsString());
+        Assert.assertEquals(
+                "ohmyinstance",
+                outputSpannerParameters.get("instanceId").getAsString());
+        Assert.assertEquals(
+                "anotherdatabase",
+                outputSpannerParameters.get("databaseId").getAsString());
+        Assert.assertEquals(
+                "anothertable",
+                outputSpannerParameters.get("table").getAsString());
+        Assert.assertFalse(outputSpannerParameters.get("createTable").getAsBoolean());
+
+        final List<String> keyFields = new ArrayList<>();
+        for(JsonElement element : outputSpannerParameters.get("keyFields").getAsJsonArray()) {
+            keyFields.add(element.getAsString());
+        }
+
+        Assert.assertEquals(Arrays.asList("Field1","Field2"), keyFields);
+    }
+
+}

--- a/src/test/resources/config/beamsql-join-bigquery-and-spanner-to-spanner.json
+++ b/src/test/resources/config/beamsql-join-bigquery-and-spanner-to-spanner.json
@@ -1,0 +1,49 @@
+{
+  "sources": [
+    {
+      "name": "BigQueryInput",
+      "module": "bigquery",
+      "parameters": {
+        "query": "SELECT BField1, BField2 FROM `myproject.mydataset.mytable` WHERE StartDate > DATE('${startDate}')"
+      }
+    },
+    {
+      "name": "SpannerInput",
+      "module": "spanner",
+      "parameters": {
+        "projectId": "myproject",
+        "instanceId": "myinstance",
+        "databaseId": "mydatabase",
+        "fields": ["SField1","SField2"]
+      }
+    }
+  ],
+  "transforms": [
+    {
+      "name": "beamsql",
+      "module": "beamsql",
+      "inputs": [
+        "BigQueryInput",
+        "SpannerInput"
+      ],
+      "parameters": {
+        "sql": "SELECT BigQueryInput.BField1 AS Field1, IF(BigQueryInput.BField2 IS NULL, SpannerInput.SField2, BigQueryInput.BField2) AS Field2 FROM BigQueryInput LEFT JOIN SpannerInput ON BigQueryInput.BField1 = SpannerInput.SField1 WHERE BigQueryInput.Date = DATE('${startDate}')"
+      }
+    }
+  ],
+  "sinks": [
+    {
+      "name": "SpannerOutput",
+      "module": "spanner",
+      "input": "beamsql",
+      "parameters": {
+        "projectId": "anotherproject",
+        "instanceId": "anotherinstance",
+        "databaseId": "anotherdatabase",
+        "table": "anothertable",
+        "createTable": ${create?c},
+        "keyFields": [${keyFields?join(',')}]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
In the config.json file, complex parameters such as SQL are also hard to describe in JSON strings, so they can be placed in GCS as external files and their paths can be specified.

However, until now, it was not possible to insert parameters to external files at runtime.
Therefore, we made it possible to propagate the runtime parameters to each module, so that the parameters can be inserted after reading the external file.

(Currently, only SQL files are supported, including BigQuerySource, SpannerSource, and BeamSQLTramsform, but we will support other modules as needed if they require runtime parameter insertion into external files.)