### PR TITLE
support handling failure records to insert bq.

### DIFF
--- a/docs/config/module/sink/bigquery.md
+++ b/docs/config/module/sink/bigquery.md
@@ -23,6 +23,11 @@ Sink module to write the input data to a specified BigQuery table.
 | partitioning | optional | String | Specifies that you want to save the data in the partition table when the destination table is generated automatically. One of `DAY` or `HOUR` is specified. The default is disabled.|
 | partitioningField | optional | String | Specify the field name you want to specify as the destination partition when saving to Partition Table. |
 | clustering | optional | String | Specify a split field name for Clustering. |
+| skipInvalidRows | optional | Boolean | Insert all valid rows of a request, even if invalid rows exist. Default is false. (this option only for streaming mode) |
+| ignoreUnknownValues | optional | Boolean | Accept rows that contain values that do not match the schema. Default is false. |
+| ignoreInsertIds | optional | Boolean | Setting this option to true disables insertId based data [deduplication offered by BigQuery](https://cloud.google.com/bigquery/streaming-data-into-bigquery#disabling_best_effort_de-duplication). Default is false. (this option only for streaming mode) |
+| withExtendedErrorInfo | optional | Boolean | Enables extended error information. Default is false. (this option only for streaming mode) |
+| failedInsertRetryPolicy | optional | Enum | Specfies a policy for handling failed inserts. You can specify one of the values `always`,`never`, or `retryTransientErrors`. Default is `retryTransientErrors` which indicates that retry all failures except for known persistent errors. (this option only for streaming mode) |
 | kmsKey | optional | String | kmsKey |
 
 ## Related example config files

--- a/src/main/java/com/mercari/solution/module/sink/BigQuerySink.java
+++ b/src/main/java/com/mercari/solution/module/sink/BigQuerySink.java
@@ -1,9 +1,6 @@
 package com.mercari.solution.module.sink;
 
-import com.google.api.services.bigquery.model.Clustering;
-import com.google.api.services.bigquery.model.TableRow;
-import com.google.api.services.bigquery.model.TableSchema;
-import com.google.api.services.bigquery.model.TimePartitioning;
+import com.google.api.services.bigquery.model.*;
 import com.google.cloud.spanner.Struct;
 import com.google.datastore.v1.Entity;
 import com.google.gson.Gson;
@@ -15,9 +12,14 @@ import com.mercari.solution.util.schema.AvroSchemaUtil;
 import com.mercari.solution.util.OptionUtil;
 import com.mercari.solution.util.converter.*;
 import com.mercari.solution.util.schema.EntitySchemaUtil;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.*;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.*;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -25,10 +27,7 @@ import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -39,15 +38,23 @@ public class BigQuerySink implements SinkModule {
     private class BigQuerySinkParameters {
 
         private String table;
-        private String partitioning;
-        private String partitioningField;
-        private String dynamicDestination;
         private String writeDisposition;
         private String createDisposition;
         private String method;
+
+        private String partitioning;
+        private String partitioningField;
         private String clustering;
+
+        private Boolean skipInvalidRows;
+        private Boolean ignoreUnknownValues;
+        private Boolean ignoreInsertIds;
+        private Boolean withExtendedErrorInfo;
+        private FailedInsertRetryPolicy failedInsertRetryPolicy;
+
+        private String dynamicDestination;
+
         private String kmsKey;
-        private String outputError;
 
         public String getTable() {
             return table;
@@ -55,30 +62,6 @@ public class BigQuerySink implements SinkModule {
 
         public void setTable(String table) {
             this.table = table;
-        }
-
-        public String getPartitioning() {
-            return partitioning;
-        }
-
-        public void setPartitioning(String partitioning) {
-            this.partitioning = partitioning;
-        }
-
-        public String getPartitioningField() {
-            return partitioningField;
-        }
-
-        public void setPartitioningField(String partitioningField) {
-            this.partitioningField = partitioningField;
-        }
-
-        public String getDynamicDestination() {
-            return dynamicDestination;
-        }
-
-        public void setDynamicDestination(String dynamicDestination) {
-            this.dynamicDestination = dynamicDestination;
         }
 
         public String getWriteDisposition() {
@@ -105,12 +88,76 @@ public class BigQuerySink implements SinkModule {
             this.method = method;
         }
 
+        public String getPartitioning() {
+            return partitioning;
+        }
+
+        public void setPartitioning(String partitioning) {
+            this.partitioning = partitioning;
+        }
+
+        public String getPartitioningField() {
+            return partitioningField;
+        }
+
+        public void setPartitioningField(String partitioningField) {
+            this.partitioningField = partitioningField;
+        }
+
+        public String getDynamicDestination() {
+            return dynamicDestination;
+        }
+
+        public void setDynamicDestination(String dynamicDestination) {
+            this.dynamicDestination = dynamicDestination;
+        }
+
         public String getClustering() {
             return clustering;
         }
 
         public void setClustering(String clustering) {
             this.clustering = clustering;
+        }
+
+        public Boolean getSkipInvalidRows() {
+            return skipInvalidRows;
+        }
+
+        public void setSkipInvalidRows(Boolean skipInvalidRows) {
+            this.skipInvalidRows = skipInvalidRows;
+        }
+
+        public Boolean getIgnoreUnknownValues() {
+            return ignoreUnknownValues;
+        }
+
+        public void setIgnoreUnknownValues(Boolean ignoreUnknownValues) {
+            this.ignoreUnknownValues = ignoreUnknownValues;
+        }
+
+        public Boolean getIgnoreInsertIds() {
+            return ignoreInsertIds;
+        }
+
+        public void setIgnoreInsertIds(Boolean ignoreInsertIds) {
+            this.ignoreInsertIds = ignoreInsertIds;
+        }
+
+        public Boolean getWithExtendedErrorInfo() {
+            return withExtendedErrorInfo;
+        }
+
+        public void setWithExtendedErrorInfo(Boolean withExtendedErrorInfo) {
+            this.withExtendedErrorInfo = withExtendedErrorInfo;
+        }
+
+        public FailedInsertRetryPolicy getFailedInsertRetryPolicy() {
+            return failedInsertRetryPolicy;
+        }
+
+        public void setFailedInsertRetryPolicy(FailedInsertRetryPolicy failedInsertRetryPolicy) {
+            this.failedInsertRetryPolicy = failedInsertRetryPolicy;
         }
 
         public String getKmsKey() {
@@ -121,26 +168,31 @@ public class BigQuerySink implements SinkModule {
             this.kmsKey = kmsKey;
         }
 
-        public String getOutputError() {
-            return outputError;
-        }
+    }
 
-        public void setOutputError(String outputError) {
-            this.outputError = outputError;
-        }
+    private enum FailedInsertRetryPolicy {
+        always,
+        never,
+        retryTransientErrors
     }
 
     public String getName() { return "bigquery"; }
 
     public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
-        return Collections.singletonMap(config.getName(), BigQuerySink.write(input, config, waits));
+        final Map<String, FCollection<?>> outputs = new HashMap<>();
+        final FCollection<?> output = BigQuerySink.write(input, config, waits);
+        outputs.put(config.getName(), output);
+        final String failuresName = config.getName() + ".failures";
+        outputs.put(failuresName, FCollection.of(failuresName, output.getCollection(), output.getDataType(), output.getAvroSchema()));
+        return outputs;
     }
 
     public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config) {
         return write(collection, config, null);
     }
 
-    public static FCollection<?> write(final FCollection<?> collection, final SinkConfig config,
+    public static FCollection<?> write(final FCollection<?> collection,
+                                       final SinkConfig config,
                                        final List<FCollection<?>> waitCollections) {
 
         final BigQuerySinkParameters parameters = new Gson().fromJson(config.getParameters(), BigQuerySinkParameters.class);
@@ -155,6 +207,7 @@ public class BigQuerySink implements SinkModule {
         switch (inputType) {
             case AVRO: {
                 final BigQueryWrite<GenericRecord> write = new BigQueryWrite<>(
+                        config.getName(),
                         collection,
                         parameters,
                         AvroWriteRequest::getElement,
@@ -162,11 +215,12 @@ public class BigQuerySink implements SinkModule {
                         s -> s.get(destinationField) == null ? "" : s.get(destinationField).toString(),
                         waitCollections);
                 final PCollection<GenericRecord> input = (PCollection<GenericRecord>) collection.getCollection();
-                final PCollection output = input.apply(config.getName(), write);
-                return FCollection.update(write.collection, output);
+                final PCollection<GenericRecord> output = input.apply(config.getName(), write);
+                return FCollection.of(config.getName(), output, DataType.AVRO, ((AvroCoder)output.getCoder()).getSchema());
             }
             case ROW: {
                 final BigQueryWrite<Row> write = new BigQueryWrite<>(
+                        config.getName(),
                         collection,
                         parameters,
                         RowToRecordConverter::convert,
@@ -174,11 +228,12 @@ public class BigQuerySink implements SinkModule {
                         s -> s.getValue(destinationField) == null ? "" : s.getValue(destinationField).toString(),
                         waitCollections);
                 final PCollection<Row> input = (PCollection<Row>) collection.getCollection();
-                final PCollection output = input.apply(config.getName(), write);
-                return FCollection.update(write.collection, output);
+                final PCollection<GenericRecord> output = input.apply(config.getName(), write);
+                return FCollection.of(config.getName(), output, DataType.AVRO, ((AvroCoder)output.getCoder()).getSchema());
             }
             case STRUCT: {
                 final BigQueryWrite<Struct> write = new BigQueryWrite<>(
+                        config.getName(),
                         collection,
                         parameters,
                         StructToRecordConverter::convert,
@@ -186,11 +241,12 @@ public class BigQuerySink implements SinkModule {
                         s -> s.isNull(destinationField) ? "" : s.getString(destinationField),
                         waitCollections);
                 final PCollection<Struct> input = (PCollection<Struct>) collection.getCollection();
-                final PCollection output = input.apply(config.getName(), write);
-                return FCollection.update(write.collection, output);
+                final PCollection<GenericRecord> output = input.apply(config.getName(), write);
+                return FCollection.of(config.getName(), output, DataType.AVRO, ((AvroCoder)output.getCoder()).getSchema());
             }
             case ENTITY: {
                 final BigQueryWrite<Entity> write = new BigQueryWrite<>(
+                        config.getName(),
                         collection,
                         parameters,
                         EntityToRecordConverter::convert,
@@ -198,16 +254,17 @@ public class BigQuerySink implements SinkModule {
                         s -> OptionUtil.ifnull(EntitySchemaUtil.getAsString(s.getPropertiesOrDefault(destinationField, null)), ""),
                         waitCollections);
                 final PCollection<Entity> input = (PCollection<Entity>) collection.getCollection();
-                final PCollection output = input.apply(config.getName(), write);
-                return FCollection.update(write.collection, output);
+                final PCollection<GenericRecord> output = input.apply(config.getName(), write);
+                return FCollection.of(config.getName(), output, DataType.AVRO, ((AvroCoder)output.getCoder()).getSchema());
             }
             default:
                 throw new IllegalArgumentException("Not supported type: " + inputType + " for BigQuerySink.");
         }
     }
 
-    public static class BigQueryWrite<T> extends PTransform<PCollection<T>, PCollection<TableRow>> {
+    public static class BigQueryWrite<T> extends PTransform<PCollection<T>, PCollection<GenericRecord>> {
 
+        private final String name;
         private final BigQuerySinkParameters parameters;
         private final SerializableFunction<AvroWriteRequest<T>, GenericRecord> convertAvroFunction;
         private final SerializableFunction<T, TableRow> convertTableRowFunction;
@@ -216,13 +273,15 @@ public class BigQuerySink implements SinkModule {
 
         private FCollection<?> collection;
 
-        private BigQueryWrite(final FCollection<?> collection,
+        private BigQueryWrite(final String name,
+                              final FCollection<?> collection,
                               final BigQuerySinkParameters parameters,
                               final SerializableFunction<AvroWriteRequest<T>, GenericRecord> convertAvroFunction,
                               final SerializableFunction<T, TableRow> convertTableRowFunction,
                               final SerializableFunction<T, String> destinationFunction,
                               final List<FCollection<?>> waitCollections) {
 
+            this.name = name;
             this.collection = collection;
             this.parameters = parameters;
             this.convertAvroFunction = convertAvroFunction;
@@ -231,7 +290,7 @@ public class BigQuerySink implements SinkModule {
             this.waitCollections = waitCollections;
         }
 
-        public PCollection<TableRow> expand(final PCollection<T> rows) {
+        public PCollection<GenericRecord> expand(final PCollection<T> rows) {
             validateParameters();
             setDefaultParameters();
 
@@ -267,15 +326,31 @@ public class BigQuerySink implements SinkModule {
             if(this.parameters.getKmsKey() != null) {
                 write = write.withKmsKey(this.parameters.getKmsKey().trim());
             }
-            if(this.parameters.getOutputError() != null) {
-                write = write.withExtendedErrorInfo();
-            }
 
             if(rows.getPipeline().getOptions().as(DataflowPipelineOptions.class).isStreaming()) {
                 LOG.info("BigQuerySink: TableRowWrite mode.");
                 write = write
                         .withMethod(BigQueryIO.Write.Method.STREAMING_INSERTS)
                         .withFormatFunction(convertTableRowFunction);
+                if(parameters.getSkipInvalidRows()) {
+                    write = write.skipInvalidRows();
+                }
+                if(parameters.getIgnoreUnknownValues()) {
+                    write = write.ignoreUnknownValues();
+                }
+                if(parameters.getIgnoreInsertIds()) {
+                    write = write.ignoreInsertIds();
+                }
+                if(parameters.getWithExtendedErrorInfo()) {
+                    write = write.withExtendedErrorInfo();
+                }
+                if(parameters.getFailedInsertRetryPolicy().equals(FailedInsertRetryPolicy.always)) {
+                    write = write.withFailedInsertRetryPolicy(InsertRetryPolicy.alwaysRetry());
+                } else if(parameters.getFailedInsertRetryPolicy().equals(FailedInsertRetryPolicy.never)) {
+                    write = write.withFailedInsertRetryPolicy(InsertRetryPolicy.neverRetry());
+                } else {
+                    write = write.withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors());
+                }
             } else {
                 if(AvroSchemaUtil.isNestedSchema(collection.getAvroSchema())) {
                     LOG.info("BigQuerySink: TableRowWrite mode.");
@@ -303,20 +378,17 @@ public class BigQuerySink implements SinkModule {
                         .apply("WriteTable", write);
             }
 
-            if(this.parameters.getOutputError() != null) {
-                writeResult.getFailedInsertsWithErr()
-                        .apply("OutputError", ParDo.of(new DoFn<BigQueryInsertError, String>() {
-                            @ProcessElement
-                            public void processElement(ProcessContext c) {
-                                //c.element().getRow()
-                            }
-                        }));
-            }
+            if(rows.getPipeline().getOptions().as(DataflowPipelineOptions.class).isStreaming()
+                    && parameters.getWithExtendedErrorInfo()) {
 
-            //return rows.getPipeline()
-            //        .apply(Create.of("wait").withCoder(StringUtf8Coder.of()))
-            //        .apply(Wait.on(writeResult.getFailedInserts()));
-            return writeResult.getFailedInserts();
+                return writeResult.getFailedInsertsWithErr()
+                        .apply("ConvertFailureRecordWithError", ParDo.of(new FailedRecordWithErrorDoFn(name, collection.getAvroSchema().toString())))
+                        .setCoder(AvroCoder.of(FailedRecordWithErrorDoFn.createOutputSchema(collection.getAvroSchema())));
+            } else {
+                return writeResult.getFailedInserts()
+                        .apply("ConvertFailureRecord", ParDo.of(new FailedRecordDoFn(name, collection.getAvroSchema().toString())))
+                        .setCoder(AvroCoder.of(collection.getAvroSchema()));
+            }
         }
 
         private void validateParameters() {
@@ -343,6 +415,113 @@ public class BigQuerySink implements SinkModule {
             } else {
                 this.parameters.setMethod(this.parameters.getMethod().trim().toUpperCase());
             }
+
+            if(parameters.getSkipInvalidRows() == null) {
+                parameters.setSkipInvalidRows(false);
+            }
+            if(parameters.getIgnoreUnknownValues() == null) {
+                parameters.setIgnoreUnknownValues(false);
+            }
+            if(parameters.getIgnoreInsertIds() == null) {
+                parameters.setIgnoreInsertIds(false);
+            }
+            if(parameters.getWithExtendedErrorInfo() == null) {
+                parameters.setWithExtendedErrorInfo(false);
+            }
+            if(parameters.getFailedInsertRetryPolicy() == null) {
+                parameters.setFailedInsertRetryPolicy(FailedInsertRetryPolicy.retryTransientErrors);
+            }
+
+        }
+
+        private static class FailedRecordDoFn extends DoFn<TableRow, GenericRecord> {
+
+            private final Counter errorCounter;
+            private final String recordSchemaString;
+            private transient Schema recordSchema;
+
+            FailedRecordDoFn(final String name, final String schemaString) {
+                this.errorCounter = Metrics.counter(name, "elements_insert_error");
+                this.recordSchemaString = schemaString;
+            }
+
+            @Setup
+            public void setup() {
+                this.recordSchema = AvroSchemaUtil.convertSchema(recordSchemaString);
+            }
+
+            @ProcessElement
+            public void processElement(ProcessContext c) {
+                errorCounter.inc();
+                final TableRow tableRow = c.element();
+                LOG.error("FailedProcessElement: " + tableRow.toString());
+                final GenericRecord record = TableRowToRecordConverter.convert(recordSchema, tableRow);
+                c.output(record);
+
+                LOG.error("Failed insert record: " + RecordToJsonConverter.convert(record));
+            }
+
+        }
+
+        private static class FailedRecordWithErrorDoFn extends DoFn<BigQueryInsertError, GenericRecord> {
+
+            private final Counter errorCounter;
+            private final String recordSchemaString;
+            private transient Schema recordSchema;
+            private transient Schema outputSchema;
+            private transient Schema errorSchema;
+
+            FailedRecordWithErrorDoFn(final String name, final String schemaString) {
+                this.errorCounter = Metrics.counter(name, "elements_insert_error");
+                this.recordSchemaString = schemaString;
+            }
+
+            @Setup
+            public void setup() {
+                this.recordSchema = AvroSchemaUtil.convertSchema(recordSchemaString);
+                this.outputSchema = createOutputSchema(recordSchema);
+                this.errorSchema = AvroSchemaUtil.unnestUnion(outputSchema.getField("errors").schema()).getElementType();
+            }
+
+            @ProcessElement
+            public void processElement(ProcessContext c) {
+                errorCounter.inc();
+                final TableRow tableRow = c.element().getRow();
+                final GenericRecord record = TableRowToRecordConverter.convert(recordSchema, tableRow);
+                final TableDataInsertAllResponse.InsertErrors errors = c.element().getError();
+                final List<GenericRecord> errorMessages = errors.getErrors() == null ? null : errors.getErrors().stream()
+                        .map(error -> new GenericRecordBuilder(errorSchema)
+                                .set("message", error.getMessage())
+                                .set("reason", error.getReason())
+                                .set("location", error.getLocation())
+                                .set("debugInfo", error.getDebugInfo())
+                                .build())
+                        .collect(Collectors.toList());
+                final GenericRecord errorRecord = new GenericRecordBuilder(this.outputSchema)
+                        .set("index", errors.getIndex())
+                        .set("errors", errorMessages)
+                        .set("record", record)
+                        .build();
+
+                c.output(errorRecord);
+
+                LOG.error("Failed insert record: " + RecordToJsonConverter.convert(errorRecord));
+            }
+
+            static Schema createOutputSchema(final Schema recordSchema) {
+                final Schema errorSchema = Schema.createRecord("errorMessage", "", "extendedErrorInfo", false, Arrays.asList(
+                        new Schema.Field("reason", AvroSchemaUtil.NULLABLE_STRING, "", (Object)null),
+                        new Schema.Field("location", AvroSchemaUtil.NULLABLE_STRING, "", (Object)null),
+                        new Schema.Field("message", AvroSchemaUtil.NULLABLE_STRING, "", (Object)null),
+                        new Schema.Field("debugInfo", AvroSchemaUtil.NULLABLE_STRING, "", (Object)null)
+                ));
+                return Schema.createRecord("extendedErrorInfo", "", "root", false, Arrays.asList(
+                        new Schema.Field("index", AvroSchemaUtil.NULLABLE_LONG, "", (Object)null),
+                        new Schema.Field("errors", Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.createArray(errorSchema)), "", (Object)null),
+                        new Schema.Field("record", recordSchema, "", (Object)null)
+                ));
+            }
+
         }
 
     }

--- a/src/main/java/com/mercari/solution/util/converter/RecordToTableRowConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/RecordToTableRowConverter.java
@@ -197,11 +197,21 @@ public class RecordToTableRowConverter {
                         .map(RecordToTableRowConverter::convertTableFieldSchema)
                         .collect(Collectors.toList());
                 return tableFieldSchema.setName(name).setType("RECORD").setFields(childTableFieldSchemas);
-            case ARRAY:
-                return tableFieldSchema
-                        .setName(name)
-                        .setType(convertTableFieldSchema(name, schema.getElementType(), AvroSchemaUtil.isNullable(schema.getElementType())).getType())
-                        .setMode("REPEATED");
+            case ARRAY: {
+                final TableFieldSchema elementSchema = convertTableFieldSchema(name, schema.getElementType(), AvroSchemaUtil.isNullable(schema.getElementType()));
+                if(elementSchema.getType().equals("RECORD")) {
+                    return tableFieldSchema
+                            .setName(name)
+                            .setType(elementSchema.getType())
+                            .setFields(elementSchema.getFields())
+                            .setMode("REPEATED");
+                } else {
+                    return tableFieldSchema
+                            .setName(name)
+                            .setType(elementSchema.getType())
+                            .setMode("REPEATED");
+                }
+            }
             case UNION:
                 return convertTableFieldSchema(name, AvroSchemaUtil.unnestUnion(schema), AvroSchemaUtil.isNullable(schema));
             case MAP:

--- a/src/main/java/com/mercari/solution/util/schema/AvroSchemaUtil.java
+++ b/src/main/java/com/mercari/solution/util/schema/AvroSchemaUtil.java
@@ -121,7 +121,7 @@ public class AvroSchemaUtil {
     private static final Pattern PATTERN_DATE3 = Pattern.compile("[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}");
     private static final Pattern PATTERN_TIME1 = Pattern.compile("[0-9]{4}");
     private static final Pattern PATTERN_TIME2 = Pattern.compile("[0-9]{2}:[0-9]{2}");
-    private static final Pattern PATTERN_TIME3 = Pattern.compile("[0-9]{4}:[0-9]{2}:[0-9]{2}");
+    private static final Pattern PATTERN_TIME3 = Pattern.compile("[0-9]{2}:[0-9]{2}:[0-9]{2}");
 
     /**
      * Convert BigQuery {@link TableSchema} object to Avro {@link Schema} object.
@@ -746,12 +746,13 @@ public class AvroSchemaUtil {
     }
 
     public static int convertTimeStringToInteger(final String timeString) {
-        if(PATTERN_TIME1.matcher(timeString).find()) {
-            return FORMAT_TIME1.parseLocalTime(timeString).getMillisOfDay();
+
+        if(PATTERN_TIME3.matcher(timeString).find()) {
+            return FORMAT_TIME3.parseLocalTime(timeString).getMillisOfDay();
         } else if(PATTERN_TIME2.matcher(timeString).find()) {
             return FORMAT_TIME2.parseLocalTime(timeString).getMillisOfDay();
-        } else if(PATTERN_TIME3.matcher(timeString).find()) {
-            return FORMAT_TIME3.parseLocalTime(timeString).getMillisOfDay();
+        } else if(PATTERN_TIME1.matcher(timeString).find()) {
+            return FORMAT_TIME1.parseLocalTime(timeString).getMillisOfDay();
         } else {
             throw new IllegalArgumentException("Illegal time string: " + timeString);
         }

--- a/src/test/java/com/mercari/solution/util/converter/TableRowToRecordConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/converter/TableRowToRecordConverterTest.java
@@ -1,0 +1,79 @@
+package com.mercari.solution.util.converter;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.mercari.solution.TestDatum;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.List;
+
+
+public class TableRowToRecordConverterTest {
+
+    @Test
+    public void convertTest() {
+        final GenericRecord originalRecord = TestDatum.generateRecord();
+        final TableRow tableRow = RecordToTableRowConverter.convert(originalRecord);
+        final GenericRecord record = TableRowToRecordConverter.convert(originalRecord.getSchema(), tableRow);
+
+        testFlatField(originalRecord, record);
+
+        final GenericRecord childRecord = (GenericRecord)record.get("recordField");
+        testFlatField((GenericRecord)record.get("recordField"), childRecord);
+        for(GenericRecord g : (List<GenericRecord>)childRecord.get("recordArrayField")) {
+            testFlatField(originalRecord, g);
+        }
+        final GenericRecord grandchild = (GenericRecord)childRecord.get("recordField");
+        testFlatField(originalRecord, grandchild);
+
+        for(GenericRecord c : (List<GenericRecord>)record.get("recordArrayField")) {
+            testFlatField(originalRecord, c);
+            final GenericRecord gc = (GenericRecord)c.get("recordField");
+            testFlatField(originalRecord, gc);
+            for(GenericRecord g : (List<GenericRecord>)c.get("recordArrayField")) {
+                testFlatField(originalRecord, g);
+            }
+        }
+    }
+
+    @Test
+    public void convertTestNull() {
+        final GenericRecord originalRecord = TestDatum.generateRecordNull();
+        final TableRow tableRow = RecordToTableRowConverter.convert(originalRecord);
+        final GenericRecord record = TableRowToRecordConverter.convert(originalRecord.getSchema(), tableRow);
+
+        testFlatField(originalRecord, record);
+
+        final GenericRecord childRecord = (GenericRecord)record.get("recordField");
+        testFlatField((GenericRecord)record.get("recordField"), childRecord);
+        for(GenericRecord g : (List<GenericRecord>)childRecord.get("recordArrayField")) {
+            testFlatField(originalRecord, g);
+        }
+        final GenericRecord grandchild = (GenericRecord)childRecord.get("recordField");
+        testFlatField(originalRecord, grandchild);
+
+        for(GenericRecord c : (List<GenericRecord>)record.get("recordArrayField")) {
+            testFlatField(originalRecord, c);
+            final GenericRecord gc = (GenericRecord)c.get("recordField");
+            testFlatField(originalRecord, gc);
+            for(GenericRecord g : (List<GenericRecord>)c.get("recordArrayField")) {
+                testFlatField(originalRecord, g);
+            }
+        }
+    }
+
+    private void testFlatField(final GenericRecord originalRecord, final GenericRecord record) {
+        Assert.assertEquals(originalRecord.get("booleanField"), record.get("booleanField"));
+        Assert.assertEquals(originalRecord.get("stringField"), record.get("stringField"));
+        Assert.assertEquals(originalRecord.get("bytesField"), record.get("bytesField"));
+        Assert.assertEquals(originalRecord.get("intField"), record.get("intField"));
+        Assert.assertEquals(originalRecord.get("longField"), record.get("longField"));
+        Assert.assertEquals(originalRecord.get("floatField"), record.get("floatField"));
+        Assert.assertEquals(originalRecord.get("doubleField"), record.get("doubleField"));
+        Assert.assertEquals(originalRecord.get("dateField"), record.get("dateField"));
+        Assert.assertEquals(originalRecord.get("timeField"), record.get("timeField"));
+        Assert.assertEquals(originalRecord.get("timestampField"), record.get("timestampField"));
+        Assert.assertEquals(originalRecord.get("decimalField"), record.get("decimalField"));
+    }
+
+}


### PR DESCRIPTION
Add the following options to handle failed streaming insertion records in BigQuery Sink.

* skipInvalidRows
* ignoreUnknownValues
* ignoreInsertIds
* withExtendedErrorInfo
* failedInsertRetryPolicy

ref: https://beam.apache.org/releases/javadoc/2.28.0/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.Write.html