### PR TITLE
Support pubsub sink protobuf format

### DIFF
--- a/docs/config/module/sink/pubsub.md
+++ b/docs/config/module/sink/pubsub.md
@@ -23,9 +23,10 @@ PubSub sink module publishes record to the specified PubSub topic.
 | timestampAttribute | optional | String | Specify the attribute name when you want to save the event time of the record as attribute value. |
 | maxBatchSize | optional | Integer | Specify the number of buffers to send to PubSub at one time. |
 | maxBatchBytesSize | optional | Integer | Specifies the buffer byte size to be sent to PubSub at one time. |
-| protobufDescriptorPath | optional | String | When `protobuf` is specified as the `format`, specify the path of the GCS where the descriptor file for serialization is located. |
+| protobufDescriptor | optional | String | When `protobuf` is specified as the `format`, specify the path of the GCS where the descriptor file for serialization is located. |
 | protobufMessageName | optional | String | When `protobuf` is specified as the `format`, Specify the full name(contains package name) of the target message. |
 
 ## Related example config files
 
 * [BigQuery to Cloud PubSub](../../../../examples/bigquery-to-pubsub.json)
+* [Cloud PubSub(protobuf) to BeamSQL to Cloud PubSub(protobuf)](../../../../examples/pubsub-protobuf-to-beamsql-to-pubsub-protobuf.json)

--- a/docs/config/module/sink/pubsub.md
+++ b/docs/config/module/sink/pubsub.md
@@ -17,12 +17,14 @@ PubSub sink module publishes record to the specified PubSub topic.
 | parameter | optional | type | description |
 | --- | --- | --- | --- |
 | topic | required | String | Specify the PubSub topic name of the destination. (projects/{gcp project}/topics/{topic name}) |
-| format | required | String | Specifies the format of the records to publish. Currently supporting `json` and `avro`. |
+| format | required | String | Specifies the format of the records to publish. Currently supporting `json`, `avro` and `protobuf`. |
 | attributes | optional | Array<String\> | Specify the field names you want to register as attributes in the PubSub message. |
 | idAttribute | optional | String | Specify a field name with a value when you want to give an ID to a PubSub message to ensure uniqueness. |
 | timestampAttribute | optional | String | Specify the attribute name when you want to save the event time of the record as attribute value. |
 | maxBatchSize | optional | Integer | Specify the number of buffers to send to PubSub at one time. |
 | maxBatchBytesSize | optional | Integer | Specifies the buffer byte size to be sent to PubSub at one time. |
+| protobufDescriptorPath | optional | String | When `protobuf` is specified as the `format`, specify the path of the GCS where the descriptor file for serialization is located. |
+| protobufMessageName | optional | String | When `protobuf` is specified as the `format`, Specify the full name(contains package name) of the target message. |
 
 ## Related example config files
 

--- a/docs/config/module/source/SCHEMA.md
+++ b/docs/config/module/source/SCHEMA.md
@@ -2,9 +2,9 @@
 
 | name | optional | type | description |
 | --- | --- | --- | --- |
-| avroSchema | selective required | String | GCS path where you put the Avro schema file. |
 | fields |  selective required | Array<Field\> | Specify an array of type Field below. |
-
+| avroSchema | selective required | String | GCS path where you put the Avro schema file. |
+| protobufDescriptor | selective required | String | GCS path where you put the protobuf descriptor file. |
 
 ## Field
 

--- a/docs/config/module/source/pubsub.md
+++ b/docs/config/module/source/pubsub.md
@@ -18,11 +18,15 @@ PubSub source module for receiving message from specified Cloud PubSub topic or 
 | --- | --- | --- | --- |
 | topic | selective required | String | Specify the topic to read data from PubSub; unnecessary if subscription is specified |
 | subscription | selective required | String | Specify the subscription to read data from PubSub; unnecessary if topic is specified |
-| format | required | String | Specify the format. Currently support `avro` or `json` |
+| format | required | String | Specify the format. Currently support `avro`, `json` or `protobuf` |
 | idAttribute | optional | String | Specify the Attribute name you want to identify as id. [ref](https://cloud.google.com/dataflow/docs/concepts/streaming-with-cloud-pubsub#efficient_deduplication) |
+| messageName | optional | String | When `protobuf` is specified as the `format`, Specify the full name(contains package name) of the target message. |
+
+※ If `protobuf` is specified in the `format`, both `protobufDescriptor` at [Schema](SCHEMA.md) and `messageName` at parameters must be specified.
 
 ## Related example config files
 
 * [Cloud PubSub(Avro) to BigQuery](../../../../examples/pubsub-avro-to-bigquery.json)
 * [Cloud PubSub(Avro) to Cloud Spanner](../../../../examples/pubsub-avro-to-spanner.json)
 * [Cloud PubSub(Json) to BeamSQL to Cloud PubSub(Json)](../../../../examples/pubsub-to-beamsql-to-pubsub.json)
+* [Cloud PubSub(protobuf) to BeamSQL to Cloud PubSub(protobuf)](../../../../examples/pubsub-protobuf-to-beamsql-to-pubsub-protobuf.json)

--- a/examples/pubsub-protobuf-to-beamsql-to-pubsub-protobuf.json
+++ b/examples/pubsub-protobuf-to-beamsql-to-pubsub-protobuf.json
@@ -1,0 +1,51 @@
+{
+  "sources": [
+    {
+      "name": "pubsubInput",
+      "module": "pubsub",
+      "parameters": {
+        "subscription": "projects/myproject/subscriptions/mysubscription",
+        "format": "protobuf",
+        "messageName": "com.example.entity.MyMessage"
+      },
+      "schema": {
+        "protobufDescriptor": "gs://example-bucket/mymessage.desc"
+      }
+    }
+  ],
+  "transforms": [
+    {
+      "name": "withEventTime",
+      "module": "eventtime",
+      "inputs": [
+        "pubsubInput"
+      ],
+      "parameters": {
+        "eventtimeField": "CreatedAt"
+      }
+    },
+    {
+      "name": "beamsqlTransform",
+      "module": "beamsql",
+      "inputs": [
+        "withEventTime"
+      ],
+      "parameters": {
+        "sql": "SELECT UserID, COUNT(UserID) AS Count, SUM(Count) AS SumCount, MIN(CreatedAt) AS EarliestTime, MAX(CreatedAt) AS LatestTime FROM withEventTime GROUP BY UserID, TUMBLE(CreatedAt, 'INTERVAL 10 SECOND') HAVING SumCount > 1"
+      }
+    }
+  ],
+  "sinks": [
+    {
+      "name": "pubsubOutput",
+      "module": "pubsub",
+      "input": "beamsqlTransform",
+      "parameters": {
+        "topic": "projects/myproject/topics/mytopic",
+        "format": "protobuf",
+        "protobufDescriptor": "gs://example-bucket/resultmessage.desc",
+        "protobufMessageName": "com.example.entity.ResultMessage"
+      }
+    }
+  ]
+}

--- a/src/main/java/com/mercari/solution/module/sink/PubSubSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/PubSubSink.java
@@ -48,7 +48,7 @@ public class PubSubSink implements SinkModule {
         private String idAttribute;
         private String timestampAttribute;
 
-        private String protobufDescriptorPath;
+        private String protobufDescriptor;
         private String protobufMessageName;
 
         private Integer maxBatchSize;
@@ -94,12 +94,12 @@ public class PubSubSink implements SinkModule {
             this.timestampAttribute = timestampAttribute;
         }
 
-        public String getProtobufDescriptorPath() {
-            return protobufDescriptorPath;
+        public String getProtobufDescriptor() {
+            return protobufDescriptor;
         }
 
-        public void setProtobufDescriptorPath(String protobufDescriptorPath) {
-            this.protobufDescriptorPath = protobufDescriptorPath;
+        public void setProtobufDescriptor(String protobufDescriptor) {
+            this.protobufDescriptor = protobufDescriptor;
         }
 
         public String getProtobufMessageName() {
@@ -250,7 +250,7 @@ public class PubSubSink implements SinkModule {
                             return rows.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
                                     parameters.getAttributes(),
                                     parameters.getIdAttribute(),
-                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufDescriptor(),
                                     parameters.getProtobufMessageName(),
                                     RowSchemaUtil::getAsString,
                                     RowToProtoConverter::convert)))
@@ -261,7 +261,7 @@ public class PubSubSink implements SinkModule {
                             return records.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
                                     parameters.getAttributes(),
                                     parameters.getIdAttribute(),
-                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufDescriptor(),
                                     parameters.getProtobufMessageName(),
                                     AvroSchemaUtil::getAsString,
                                     RecordToProtoConverter::convert)))
@@ -272,7 +272,7 @@ public class PubSubSink implements SinkModule {
                             return structs.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
                                     parameters.getAttributes(),
                                     parameters.getIdAttribute(),
-                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufDescriptor(),
                                     parameters.getProtobufMessageName(),
                                     StructSchemaUtil::getAsString,
                                     StructToProtoConverter::convert)))
@@ -283,7 +283,7 @@ public class PubSubSink implements SinkModule {
                             return entities.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
                                     parameters.getAttributes(),
                                     parameters.getIdAttribute(),
-                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufDescriptor(),
                                     parameters.getProtobufMessageName(),
                                     EntitySchemaUtil::getAsString,
                                     EntityToProtoConverter::convert)))
@@ -313,8 +313,8 @@ public class PubSubSink implements SinkModule {
             }
             if(parameters.getFormat() != null) {
                 if(parameters.getFormat().equals(Format.protobuf)) {
-                    if(parameters.getProtobufDescriptorPath() == null) {
-                        errorMessages.add("PubSub sink module parameter must contain protobufDescriptorPath when set format `protobuf`");
+                    if(parameters.getProtobufDescriptor() == null) {
+                        errorMessages.add("PubSub sink module parameter must contain protobufDescriptor when set format `protobuf`");
                     }
                     if(parameters.getProtobufMessageName() == null) {
                         errorMessages.add("PubSub sink module parameter must contain protobufMessageName when set format `protobuf`");

--- a/src/main/java/com/mercari/solution/module/sink/PubSubSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/PubSubSink.java
@@ -3,15 +3,15 @@ package com.mercari.solution.module.sink;
 import com.google.cloud.spanner.Struct;
 import com.google.datastore.v1.Entity;
 import com.google.gson.Gson;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 import com.mercari.solution.config.SinkConfig;
 import com.mercari.solution.module.DataType;
 import com.mercari.solution.module.FCollection;
 import com.mercari.solution.module.SinkModule;
 import com.mercari.solution.util.converter.*;
-import com.mercari.solution.util.schema.AvroSchemaUtil;
-import com.mercari.solution.util.schema.EntitySchemaUtil;
-import com.mercari.solution.util.schema.RowSchemaUtil;
-import com.mercari.solution.util.schema.StructSchemaUtil;
+import com.mercari.solution.util.gcp.StorageUtil;
+import com.mercari.solution.util.schema.*;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -47,6 +47,9 @@ public class PubSubSink implements SinkModule {
         private List<String> attributes;
         private String idAttribute;
         private String timestampAttribute;
+
+        private String protobufDescriptorPath;
+        private String protobufMessageName;
 
         private Integer maxBatchSize;
         private Integer maxBatchBytesSize;
@@ -91,6 +94,22 @@ public class PubSubSink implements SinkModule {
             this.timestampAttribute = timestampAttribute;
         }
 
+        public String getProtobufDescriptorPath() {
+            return protobufDescriptorPath;
+        }
+
+        public void setProtobufDescriptorPath(String protobufDescriptorPath) {
+            this.protobufDescriptorPath = protobufDescriptorPath;
+        }
+
+        public String getProtobufMessageName() {
+            return protobufMessageName;
+        }
+
+        public void setProtobufMessageName(String protobufMessageName) {
+            this.protobufMessageName = protobufMessageName;
+        }
+
         public Integer getMaxBatchSize() {
             return maxBatchSize;
         }
@@ -112,7 +131,8 @@ public class PubSubSink implements SinkModule {
 
     private enum Format {
         avro,
-        json
+        json,
+        protobuf
     }
 
     public Map<String, FCollection<?>> expand(FCollection<?> input, SinkConfig config, List<FCollection<?>> waits) {
@@ -223,6 +243,56 @@ public class PubSubSink implements SinkModule {
                             throw new IllegalArgumentException("PubSubSink module not support data type: " + collection.getDataType());
                     }
                 }
+                case protobuf: {
+                    switch (collection.getDataType()) {
+                        case ROW: {
+                            final PCollection<Row> rows = (PCollection<Row>)input;
+                            return rows.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
+                                    parameters.getAttributes(),
+                                    parameters.getIdAttribute(),
+                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufMessageName(),
+                                    RowSchemaUtil::getAsString,
+                                    RowToProtoConverter::convert)))
+                                    .apply("PublishPubSub", write);
+                        }
+                        case AVRO: {
+                            final PCollection<GenericRecord> records = (PCollection<GenericRecord>)input;
+                            return records.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
+                                    parameters.getAttributes(),
+                                    parameters.getIdAttribute(),
+                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufMessageName(),
+                                    AvroSchemaUtil::getAsString,
+                                    RecordToProtoConverter::convert)))
+                                    .apply("PublishPubSub", write);
+                        }
+                        case STRUCT: {
+                            final PCollection<Struct> structs = (PCollection<Struct>)input;
+                            return structs.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
+                                    parameters.getAttributes(),
+                                    parameters.getIdAttribute(),
+                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufMessageName(),
+                                    StructSchemaUtil::getAsString,
+                                    StructToProtoConverter::convert)))
+                                    .apply("PublishPubSub", write);
+                        }
+                        case ENTITY: {
+                            final PCollection<Entity> entities = (PCollection<Entity>)input;
+                            return entities.apply("ToMessage", ParDo.of(new ProtobufPubsubMessageDoFn<>(
+                                    parameters.getAttributes(),
+                                    parameters.getIdAttribute(),
+                                    parameters.getProtobufDescriptorPath(),
+                                    parameters.getProtobufMessageName(),
+                                    EntitySchemaUtil::getAsString,
+                                    EntityToProtoConverter::convert)))
+                                    .apply("PublishPubSub", write);
+                        }
+                        default:
+                            throw new IllegalArgumentException("PubSubSink module not support data type: " + collection.getDataType());
+                    }
+                }
                 default:
                     throw new IllegalArgumentException("PubSubSink module not support format: " + parameters.getFormat());
             }
@@ -236,10 +306,20 @@ public class PubSubSink implements SinkModule {
             // check required parameters filled
             final List<String> errorMessages = new ArrayList<>();
             if(parameters.getTopic() == null) {
-                errorMessages.add("PubSub module parameter must contain topic");
+                errorMessages.add("PubSub sink module parameter must contain topic");
             }
             if(parameters.getFormat() == null) {
-                errorMessages.add("PubSub module parameter must contain format");
+                errorMessages.add("PubSub sink module parameter must contain format");
+            }
+            if(parameters.getFormat() != null) {
+                if(parameters.getFormat().equals(Format.protobuf)) {
+                    if(parameters.getProtobufDescriptorPath() == null) {
+                        errorMessages.add("PubSub sink module parameter must contain protobufDescriptorPath when set format `protobuf`");
+                    }
+                    if(parameters.getProtobufMessageName() == null) {
+                        errorMessages.add("PubSub sink module parameter must contain protobufMessageName when set format `protobuf`");
+                    }
+                }
             }
             if(errorMessages.size() > 0) {
                 throw new IllegalArgumentException(errorMessages.stream().collect(Collectors.joining(", ")));
@@ -330,6 +410,52 @@ public class PubSubSink implements SinkModule {
 
         }
 
+        private static class ProtobufPubsubMessageDoFn<T> extends PubsubMessageDoFn<T> {
+
+            private final String descriptorPath;
+            private final String messageName;
+            private final FieldGetter<T> getter;
+            private final ProtoConverter<T> converter;
+
+            private transient Descriptors.Descriptor descriptor;
+
+            ProtobufPubsubMessageDoFn(final List<String> attributes,
+                                      final String idAttribute,
+                                      final String descriptorPath,
+                                      final String messageName,
+                                      final FieldGetter<T> getter,
+                                      final ProtoConverter<T> converter) {
+
+                super(attributes, idAttribute);
+                this.descriptorPath = descriptorPath;
+                this.messageName = messageName;
+                this.getter = getter;
+                this.converter = converter;
+            }
+
+            @Setup
+            public void setup() {
+                final byte[] bytes = StorageUtil.readBytes(descriptorPath);
+                final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(bytes);
+                this.descriptor = descriptors.get(messageName);
+            }
+
+            @Override
+            String getString(T element, String fieldName) {
+                return getter.getString(element, fieldName);
+            }
+
+            @Override
+            byte[] encode(T element) {
+                final DynamicMessage message = converter.convert(descriptor, element);
+                if(message == null) {
+                    return null;
+                }
+                return message.toByteArray();
+            }
+
+        }
+
         private static abstract class PubsubMessageDoFn<T> extends DoFn<T, PubsubMessage> {
 
             private final List<String> attributes;
@@ -385,6 +511,10 @@ public class PubSubSink implements SinkModule {
 
     private interface JsonConverter<T> extends Serializable {
         String convert(final T value);
+    }
+
+    private interface ProtoConverter<T> extends Serializable {
+        DynamicMessage convert(final Descriptors.Descriptor messageDescriptor, final T value);
     }
 
 }

--- a/src/main/java/com/mercari/solution/util/converter/EntityToProtoConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/EntityToProtoConverter.java
@@ -1,0 +1,173 @@
+package com.mercari.solution.util.converter;
+
+import com.google.datastore.v1.Entity;
+import com.google.datastore.v1.Value;
+import com.google.protobuf.*;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+
+import java.time.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EntityToProtoConverter {
+
+    public static DynamicMessage convert(final Descriptors.Descriptor messageDescriptor, final Entity entity) {
+        final DynamicMessage.Builder builder = DynamicMessage.newBuilder(messageDescriptor);
+        for(final Descriptors.FieldDescriptor field : messageDescriptor.getFields()) {
+            final Value value = entity.getPropertiesOrDefault(field.getName(), null);
+            if(field.isRepeated()) {
+                if(field.isMapField()) {
+                    // NOT support map
+                    continue;
+                } else {
+                    if(value == null
+                            || !value.getValueTypeCase().equals(Value.ValueTypeCase.ARRAY_VALUE)) {
+                        continue;
+                    }
+                    final List<Object> objects = value.getArrayValue().getValuesList().stream()
+                            .map(v -> convertValue(field, v))
+                            .collect(Collectors.toList());
+                    for(final Object fieldValue : objects) {
+                        builder.addRepeatedField(field, fieldValue);
+                    }
+                }
+            } else {
+                final Object fieldValue = convertValue(field, value);
+                builder.setField(field, fieldValue);
+            }
+        }
+        return builder.build();
+    }
+
+    private static Object convertValue(final Descriptors.FieldDescriptor field, final Value value) {
+
+        if(value == null) {
+            return null;
+        }
+
+        switch (value.getValueTypeCase()) {
+            case NULL_VALUE:
+            case VALUETYPE_NOT_SET:
+                return null;
+        }
+
+        switch (field.getJavaType()) {
+            case BOOLEAN:
+                return value.getBooleanValue();
+            case INT:
+                return Long.valueOf(value.getIntegerValue()).intValue();
+            case LONG:
+                return value.getIntegerValue();
+            case FLOAT:
+                return Double.valueOf(value.getDoubleValue()).floatValue();
+            case DOUBLE:
+                return value.getDoubleValue();
+            case STRING:
+                return value.getStringValue();
+            case ENUM: {
+                return field.getEnumType().findValueByName(value.getStringValue());
+            }
+            case BYTE_STRING:
+                return value.getBlobValue();
+            case MESSAGE: {
+                switch (ProtoSchemaUtil.ProtoType.of(field.getMessageType().getFullName())) {
+                    case BOOL_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.getBooleanValue())
+                                .build();
+                    case BYTES_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.getBlobValue())
+                                .build();
+                    case STRING_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.getStringValue())
+                                .build();
+                    case INT32_VALUE:
+                    case UINT32_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), Long.valueOf(value.getIntegerValue()).intValue())
+                                .build();
+                    case INT64_VALUE:
+                    case UINT64_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.getIntegerValue())
+                                .build();
+                    case FLOAT_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), Double.valueOf(value.getDoubleValue()).floatValue())
+                                .build();
+                    case DOUBLE_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.getDoubleValue())
+                                .build();
+                    case DATE: {
+                        final LocalDate date = LocalDate.parse(value.getStringValue());
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("year"), date.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), date.getMonthValue())
+                                .setField(field.getMessageType().findFieldByName("day"), date.getDayOfMonth())
+                                .build();
+                    }
+                    case TIME: {
+                        final LocalTime time = LocalTime.parse(value.getStringValue());
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("hours"), time.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), time.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), time.getSecond())
+                                .setField(field.getMessageType().findFieldByName("nanos"), time.getNano())
+                                .build();
+                    }
+                    case DATETIME: {
+                        final Descriptors.FieldDescriptor timezone = field.getMessageType().findFieldByName("time_zone");
+                        Timestamp timestamp = value.getTimestampValue();
+                        final ZonedDateTime dt = java.time.Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).atZone(ZoneId.of(ZoneOffset.UTC.getId()));
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(timezone,
+                                        DynamicMessage.newBuilder(timezone.getMessageType())
+                                                .setField(timezone.getMessageType().findFieldByName("id"), ZoneOffset.UTC.getId())
+                                                .build())
+                                .setField(field.getMessageType().findFieldByName("year"), dt.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), dt.getMonthValue())
+                                .setField(field.getMessageType().findFieldByName("day"), dt.getDayOfMonth())
+                                .setField(field.getMessageType().findFieldByName("hours"), dt.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), dt.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), dt.getSecond())
+                                .build();
+                    }
+                    case TIMESTAMP:
+                        final Timestamp instant = value.getTimestampValue();
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("seconds"), instant.getSeconds())
+                                .setField(field.getMessageType().findFieldByName("nanos"), instant.getNanos())
+                                .build();
+                    case ANY: {
+
+                        return Any.newBuilder().setValue(ByteString.copyFromUtf8(value.toString())).build();
+                    }
+                    case EMPTY: {
+                        return Empty.newBuilder().build();
+                    }
+                    case NULL_VALUE:
+                        return NullValue.NULL_VALUE;
+                    case CUSTOM:
+                    default: {
+                        switch (value.getValueTypeCase()) {
+                            case ENTITY_VALUE:
+                                return convert(field.getMessageType(), value.getEntityValue());
+                            case KEY_VALUE:
+                                // TODO
+                            default:
+                                return null;
+                        }
+                    }
+                }
+
+            }
+            default: {
+                throw new IllegalArgumentException("");
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/mercari/solution/util/converter/RecordToProtoConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/RecordToProtoConverter.java
@@ -1,0 +1,200 @@
+package com.mercari.solution.util.converter;
+
+import com.google.protobuf.*;
+import com.mercari.solution.util.schema.AvroSchemaUtil;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class RecordToProtoConverter {
+
+    public static DynamicMessage convert(final Descriptors.Descriptor messageDescriptor, final GenericRecord record) {
+        final DynamicMessage.Builder builder = DynamicMessage.newBuilder(messageDescriptor);
+        if(record == null) {
+            return builder.build();
+        }
+        final Schema schema = record.getSchema();
+        for(final Descriptors.FieldDescriptor field : messageDescriptor.getFields()) {
+            final Schema fieldSchema = AvroSchemaUtil.unnestUnion(schema.getField(field.getName()).schema());
+            if(field.isRepeated()) {
+                if(field.isMapField()) {
+                    // NOT support map
+                    continue;
+                } else {
+                    final List<Object> objects = Optional.ofNullable((List)record.get(field.getName())).orElse(new ArrayList());
+                    for(final Object value : objects) {
+                        builder.addRepeatedField(field, convertValue(field, AvroSchemaUtil.unnestUnion(fieldSchema.getElementType()), value));
+                    }
+                }
+            } else {
+                final Object value = convertValue(field, fieldSchema, record.get(field.getName()));
+                builder.setField(field, value);
+            }
+        }
+        return builder.build();
+    }
+
+    private static Object convertValue(final Descriptors.FieldDescriptor field, final Schema schema, final Object value) {
+
+        if(value == null) {
+            return null;
+        }
+
+        switch (field.getJavaType()) {
+            case BOOLEAN:
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                return value;
+            case STRING:
+                return value.toString();
+            case ENUM: {
+                return field.getEnumType().findValueByName(value.toString());
+            }
+            case BYTE_STRING:
+                return ByteString.copyFrom(((ByteBuffer) value));
+            case MESSAGE: {
+                switch (ProtoSchemaUtil.ProtoType.of(field.getMessageType().getFullName())) {
+                    case BOOL_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value)
+                                .build();
+                    case BYTES_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), ByteString.copyFrom((ByteBuffer) value))
+                                .build();
+                    case STRING_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.toString())
+                                .build();
+                    case INT32_VALUE:
+                    case UINT32_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Integer)value)
+                                .build();
+                    case INT64_VALUE:
+                    case UINT64_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Long)value)
+                                .build();
+                    case FLOAT_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Float)value)
+                                .build();
+                    case DOUBLE_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Double)value)
+                                .build();
+                    case DATE: {
+                        if(!schema.getType().equals(Schema.Type.INT)) {
+                            throw new IllegalArgumentException("Date field: " + field.getName() + " type is not INT but " + schema.getType().getName() + " with LogicalType: " + schema.getLogicalType());
+                        }
+                        final int epochDay = (Integer) value;
+                        final LocalDate date = LocalDate.ofEpochDay(epochDay);
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("year"), date.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), date.getMonthValue())
+                                .setField(field.getMessageType().findFieldByName("day"), date.getDayOfMonth())
+                                .build();
+                    }
+                    case TIME: {
+                        if(!schema.getType().equals(Schema.Type.INT) && !schema.getType().equals(Schema.Type.LONG)) {
+                            throw new IllegalArgumentException("Time field: " + field.getName() + " type is not INT,LONG but " + schema.getType().getName() + " with LogicalType: " + schema.getLogicalType());
+                        }
+
+                        final LocalTime time;
+                        if(LogicalTypes.timeMillis().equals(schema.getLogicalType())) {
+                            time = LocalTime.ofNanoOfDay(1000L * 1000L * (Integer) value);
+                        } else if(LogicalTypes.timeMicros().equals(schema.getLogicalType())) {
+                            time = LocalTime.ofNanoOfDay(1000L * (Long) value);
+                        } else {
+                            throw new IllegalArgumentException("Time field: " + field.getName() + " logicalType is illegal: " + schema.getLogicalType());
+                        }
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("hours"), time.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), time.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), time.getSecond())
+                                .setField(field.getMessageType().findFieldByName("nanos"), time.getNano())
+                                .build();
+                    }
+                    case DATETIME: {
+                        final Descriptors.FieldDescriptor timezone = field.getMessageType().findFieldByName("time_zone");
+                        if(!schema.getType().equals(Schema.Type.LONG)) {
+                            throw new IllegalArgumentException("DateTime field: " + field.getName() + " type is not LONG but " + schema.getType().getName() + " with LogicalType: " + schema.getLogicalType());
+                        }
+
+                        final Long epoch = (Long) value;
+                        final LocalDateTime dt;
+                        if(LogicalTypes.timestampMillis().equals(schema.getLogicalType())) {
+                            dt = LocalDateTime.ofEpochSecond(epoch/1000, (int)(1000 * 1000 * (epoch%1000)), ZoneOffset.UTC);
+                        } else if(LogicalTypes.timestampMicros().equals(schema.getLogicalType())) {
+                            dt = LocalDateTime.ofEpochSecond(epoch/1000_000, (int)(1000 * (epoch%1000_000)), ZoneOffset.UTC);
+                        } else {
+                            throw new IllegalArgumentException("DateTime field: " + field.getName() + " logicalType is illegal: " + schema.getLogicalType());
+                        }
+
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(timezone,
+                                        DynamicMessage.newBuilder(timezone.getMessageType())
+                                                .setField(timezone.getMessageType().findFieldByName("id"), ZoneOffset.UTC.getId())
+                                                .build())
+                                .setField(field.getMessageType().findFieldByName("year"), dt.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), dt.getMonthValue())
+                                .setField(field.getMessageType().findFieldByName("day"), dt.getDayOfMonth())
+                                .setField(field.getMessageType().findFieldByName("hours"), dt.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), dt.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), dt.getSecond())
+                                .build();
+                    }
+                    case TIMESTAMP:
+                        if(!schema.getType().equals(Schema.Type.LONG)) {
+                            throw new IllegalArgumentException("Timestamp field: " + field.getName() + " type is not LONG but " + schema.getType().getName() + " with LogicalType: " + schema.getLogicalType());
+                        }
+
+                        final Long epoch = (Long) value;
+                        final java.time.Instant instant;
+                        if(LogicalTypes.timestampMillis().equals(schema.getLogicalType())) {
+                            instant = java.time.Instant.ofEpochSecond(epoch/1000, (int)(1000 * 1000 * (epoch%1000)));
+                        } else if(LogicalTypes.timestampMicros().equals(schema.getLogicalType())) {
+                            instant = java.time.Instant.ofEpochSecond(epoch/1000_000, (int)(1000 * (epoch%1000_000)));
+                        } else {
+                            throw new IllegalArgumentException("DateTime field: " + field.getName() + " logicalType is illegal: " + schema.getLogicalType());
+                        }
+
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("seconds"), instant.getEpochSecond())
+                                .setField(field.getMessageType().findFieldByName("nanos"), instant.getNano())
+                                .build();
+                    case ANY: {
+                        return Any.newBuilder().setValue(ByteString.copyFromUtf8(value.toString())).build();
+                    }
+                    case EMPTY: {
+                        return Empty.newBuilder().build();
+                    }
+                    case NULL_VALUE:
+                        return NullValue.NULL_VALUE;
+                    case CUSTOM:
+                    default: {
+                        return convert(field.getMessageType(), (GenericRecord) value);
+                    }
+                }
+
+            }
+            default: {
+                throw new IllegalArgumentException("");
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/mercari/solution/util/converter/RowToProtoConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/RowToProtoConverter.java
@@ -1,0 +1,159 @@
+package com.mercari.solution.util.converter;
+
+import com.google.protobuf.*;
+import com.google.protobuf.util.Timestamps;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Instant;
+
+import java.time.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
+
+public class RowToProtoConverter {
+
+    public static Descriptors.Descriptor convertSchema(final Schema schema) {
+        final DescriptorProtos.DescriptorProto.Builder builder = DescriptorProtos.DescriptorProto.newBuilder();
+        for(final Schema.Field field : schema.getFields()) {
+            //builder.addField()
+        }
+        return builder.getDescriptorForType();
+    }
+
+    public static DynamicMessage convert(final Descriptors.Descriptor messageDescriptor, final Row row) {
+        final DynamicMessage.Builder builder = DynamicMessage.newBuilder(messageDescriptor);
+        for(final Descriptors.FieldDescriptor field : messageDescriptor.getFields()) {
+            if(field.isRepeated()) {
+                if(field.isMapField()) {
+                    // NOT support map
+                    continue;
+                } else {
+                    final Collection<Object> objects = Optional.ofNullable(row.getArray(field.getName())).orElse(new ArrayList<>());
+                    for(final Object value : objects) {
+                        builder.addRepeatedField(field, convertValue(field, value));
+                    }
+                }
+            } else {
+                final Object value = convertValue(field, row.getValue(field.getName()));
+                builder.setField(field, value);
+            }
+        }
+        return builder.build();
+    }
+
+    private static Object convertValue(final Descriptors.FieldDescriptor field, final Object value) {
+
+        if(value == null) {
+            return null;
+        }
+
+        switch (field.getJavaType()) {
+            case BOOLEAN:
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+            case STRING:
+                return value;
+            case ENUM: {
+                final EnumerationType.Value enumValue = (EnumerationType.Value) value;
+                return field.getEnumType().findValueByNumber(enumValue.getValue());
+            }
+            case BYTE_STRING:
+                return ByteString.copyFrom(((byte[]) value));
+            case MESSAGE: {
+                switch (ProtoSchemaUtil.ProtoType.of(field.getMessageType().getFullName())) {
+                    case BOOL_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value)
+                                .build();
+                    case BYTES_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), ByteString.copyFrom((byte[]) value))
+                                .build();
+                    case STRING_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), value.toString())
+                                .build();
+                    case INT32_VALUE:
+                    case UINT32_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Integer)value)
+                                .build();
+                    case INT64_VALUE:
+                    case UINT64_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Long)value)
+                                .build();
+                    case FLOAT_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Float)value)
+                                .build();
+                    case DOUBLE_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), (Double)value)
+                                .build();
+                    case DATE: {
+                        final LocalDate date = (LocalDate) value;
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("year"), date.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), date.getMonthValue())
+                                .setField(field.getMessageType().findFieldByName("day"), date.getDayOfMonth())
+                                .build();
+                    }
+                    case TIME: {
+                        final LocalTime time = (LocalTime) value;
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("hours"), time.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), time.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), time.getSecond())
+                                .setField(field.getMessageType().findFieldByName("nanos"), time.getNano())
+                                .build();
+                    }
+                    case DATETIME: {
+                        final Descriptors.FieldDescriptor timezone = field.getMessageType().findFieldByName("time_zone");
+                        final org.joda.time.DateTime dt = ((Instant) value).toDateTime(DateTimeZone.UTC);
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(timezone,
+                                        DynamicMessage.newBuilder(timezone.getMessageType())
+                                                .setField(timezone.getMessageType().findFieldByName("id"), ZoneOffset.UTC.getId())
+                                                .build())
+                                .setField(field.getMessageType().findFieldByName("year"), dt.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), dt.getMonthOfYear())
+                                .setField(field.getMessageType().findFieldByName("day"), dt.getDayOfMonth())
+                                .setField(field.getMessageType().findFieldByName("hours"), dt.getHourOfDay())
+                                .setField(field.getMessageType().findFieldByName("minutes"), dt.getMinuteOfHour())
+                                .setField(field.getMessageType().findFieldByName("seconds"), dt.getSecondOfMinute())
+                                .build();
+                    }
+                    case TIMESTAMP:
+                        final Timestamp instant = Timestamps.fromMillis(((Instant) value).getMillis());
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("seconds"), instant.getSeconds())
+                                .setField(field.getMessageType().findFieldByName("nanos"), instant.getNanos())
+                                .build();
+                    case ANY:
+                        return Any.newBuilder().setValue(ByteString.copyFromUtf8(value.toString())).build();
+                    case EMPTY:
+                        return Empty.newBuilder().build();
+                    case NULL_VALUE:
+                        return NullValue.NULL_VALUE;
+                    case CUSTOM:
+                    default: {
+                        return convert(field.getMessageType(), (Row) value);
+                    }
+                }
+
+            }
+            default: {
+                throw new IllegalArgumentException("");
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/mercari/solution/util/converter/StructToProtoConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/StructToProtoConverter.java
@@ -1,0 +1,307 @@
+package com.mercari.solution.util.converter;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.Date;
+import com.google.cloud.spanner.Struct;
+import com.google.protobuf.*;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+
+import java.time.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StructToProtoConverter {
+
+    public static DynamicMessage convert(final Descriptors.Descriptor messageDescriptor, final Struct struct) {
+        final DynamicMessage.Builder builder = DynamicMessage.newBuilder(messageDescriptor);
+        if(struct == null) {
+            return builder.build();
+        }
+        for(final Descriptors.FieldDescriptor field : messageDescriptor.getFields()) {
+            if(field.isRepeated()) {
+                if(field.isMapField()) {
+                    // NOT support map
+                    continue;
+                } else {
+                    final List<?> objects = convertValues(field, struct);
+                    for(final Object value : objects) {
+                        builder.addRepeatedField(field, value);
+                    }
+                }
+            } else {
+                final Object value = convertValue(field, struct);
+                builder.setField(field, value);
+            }
+        }
+        return builder.build();
+    }
+
+    private static Object convertValue(final Descriptors.FieldDescriptor field, final Struct struct) {
+
+        if(struct == null) {
+            return null;
+        }
+        if(struct.isNull(field.getName())) {
+            return null;
+        }
+
+        switch (field.getJavaType()) {
+            case BOOLEAN:
+                return struct.getBoolean(field.getName());
+            case INT:
+                return Long.valueOf(struct.getLong(field.getName())).intValue();
+            case LONG:
+                return struct.getLong(field.getName());
+            case FLOAT:
+                return Double.valueOf(struct.getDouble(field.getName())).floatValue();
+            case DOUBLE:
+                return struct.getDouble(field.getName());
+            case STRING:
+                return struct.getString(field.getName());
+            case ENUM:
+                return field.getEnumType().findValueByName(struct.getString(field.getName()));
+            case BYTE_STRING:
+                return ByteString.copyFrom(struct.getBytes(field.getName()).toByteArray());
+            case MESSAGE: {
+                switch (ProtoSchemaUtil.ProtoType.of(field.getMessageType().getFullName())) {
+                    case BOOL_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), struct.getBoolean(field.getName()))
+                                .build();
+                    case BYTES_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), ByteString.copyFrom(struct.getBytes(field.getName()).toByteArray()))
+                                .build();
+                    case STRING_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), struct.getString(field.getName()))
+                                .build();
+                    case INT32_VALUE:
+                    case UINT32_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), Long.valueOf(struct.getLong(field.getName())).intValue())
+                                .build();
+                    case INT64_VALUE:
+                    case UINT64_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), struct.getLong(field.getName()))
+                                .build();
+                    case FLOAT_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), Double.valueOf(struct.getDouble(field.getName())).floatValue())
+                                .build();
+                    case DOUBLE_VALUE:
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("value"), struct.getDouble(field.getName()))
+                                .build();
+                    case DATE: {
+                        final Date date = struct.getDate(field.getName());
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("year"), date.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), date.getMonth())
+                                .setField(field.getMessageType().findFieldByName("day"), date.getDayOfMonth())
+                                .build();
+                    }
+                    case TIME: {
+                        final LocalTime time = LocalTime.parse(struct.getString(field.getName()));
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("hours"), time.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), time.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), time.getSecond())
+                                .setField(field.getMessageType().findFieldByName("nanos"), time.getNano())
+                                .build();
+                    }
+                    case DATETIME: {
+                        final Descriptors.FieldDescriptor timezone = field.getMessageType().findFieldByName("time_zone");
+                        final com.google.cloud.Timestamp timestamp = struct.getTimestamp(field.getName());
+                        final ZonedDateTime dt = java.time.Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).atZone(ZoneId.of(ZoneOffset.UTC.getId()));
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(timezone,
+                                        DynamicMessage.newBuilder(timezone.getMessageType())
+                                                .setField(timezone.getMessageType().findFieldByName("id"), ZoneOffset.UTC.getId())
+                                                .build())
+                                .setField(field.getMessageType().findFieldByName("year"), dt.getYear())
+                                .setField(field.getMessageType().findFieldByName("month"), dt.getMonthValue())
+                                .setField(field.getMessageType().findFieldByName("day"), dt.getDayOfMonth())
+                                .setField(field.getMessageType().findFieldByName("hours"), dt.getHour())
+                                .setField(field.getMessageType().findFieldByName("minutes"), dt.getMinute())
+                                .setField(field.getMessageType().findFieldByName("seconds"), dt.getSecond())
+                                .build();
+                    }
+                    case TIMESTAMP:
+                        final com.google.cloud.Timestamp timestamp = struct.getTimestamp(field.getName());
+                        return DynamicMessage.newBuilder(field.getMessageType())
+                                .setField(field.getMessageType().findFieldByName("seconds"), timestamp.getSeconds())
+                                .setField(field.getMessageType().findFieldByName("nanos"), timestamp.getNanos())
+                                .build();
+                    case ANY: {
+                        return Any.newBuilder().setValue(ByteString.copyFromUtf8(struct.getString(field.getName()))).build();
+                    }
+                    case EMPTY: {
+                        return Empty.newBuilder().build();
+                    }
+                    case NULL_VALUE:
+                        return NullValue.NULL_VALUE;
+                    case CUSTOM:
+                    default: {
+                        return convert(field.getMessageType(), struct.getStruct(field.getName()));
+                    }
+                }
+
+            }
+            default: {
+                throw new IllegalArgumentException("");
+            }
+        }
+
+    }
+
+    private static List<?> convertValues(final Descriptors.FieldDescriptor field, final Struct struct) {
+        if(struct == null) {
+            return new ArrayList<>();
+        }
+        if(struct.isNull(field.getName())) {
+            return new ArrayList<>();
+        }
+
+        switch (field.getJavaType()) {
+            case BOOLEAN:
+                return struct.getBooleanList(field.getName());
+            case INT:
+                return struct.getLongList(field.getName()).stream()
+                        .map(Long::intValue)
+                        .collect(Collectors.toList());
+            case LONG:
+                return struct.getLongList(field.getName());
+            case FLOAT:
+                return struct.getDoubleList(field.getName()).stream()
+                        .map(Double::floatValue)
+                        .collect(Collectors.toList());
+            case DOUBLE:
+                return struct.getDoubleList(field.getName());
+            case STRING:
+                return struct.getStringList(field.getName());
+            case ENUM:
+                return struct.getStringList(field.getName()).stream()
+                        .map(s -> field.getEnumType().findValueByName(s))
+                        .collect(Collectors.toList());
+            case BYTE_STRING:
+                return struct.getBytesList(field.getName()).stream()
+                        .map(ByteArray::toByteArray)
+                        .map(ByteString::copyFrom)
+                        .collect(Collectors.toList());
+            case MESSAGE: {
+                switch (ProtoSchemaUtil.ProtoType.of(field.getMessageType().getFullName())) {
+                    case BOOL_VALUE:
+                        return struct.getBooleanList(field.getName()).stream()
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), b)
+                                        .build())
+                                .collect(Collectors.toList());
+                    case BYTES_VALUE:
+                        return struct.getBytesList(field.getName()).stream()
+                                .map(ByteArray::toByteArray)
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), ByteString.copyFrom(b))
+                                        .build())
+                                .collect(Collectors.toList());
+                    case STRING_VALUE:
+                        return struct.getStringList(field.getName()).stream()
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), b)
+                                        .build())
+                                .collect(Collectors.toList());
+                    case INT32_VALUE:
+                    case UINT32_VALUE:
+                        return struct.getLongList(field.getName()).stream()
+                                .map(Long::intValue)
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), b)
+                                        .build())
+                                .collect(Collectors.toList());
+                    case INT64_VALUE:
+                    case UINT64_VALUE:
+                        return struct.getLongList(field.getName()).stream()
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), b)
+                                        .build())
+                                .collect(Collectors.toList());
+                    case FLOAT_VALUE:
+                        return struct.getDoubleList(field.getName()).stream()
+                                .map(Double::floatValue)
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), b)
+                                        .build())
+                                .collect(Collectors.toList());
+                    case DOUBLE_VALUE:
+                        return struct.getDoubleList(field.getName()).stream()
+                                .map(b -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("value"), b)
+                                        .build())
+                                .collect(Collectors.toList());
+                    case DATE:
+                        return struct.getDateList(field.getName()).stream()
+                                .map(date -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("year"), date.getYear())
+                                        .setField(field.getMessageType().findFieldByName("month"), date.getMonth())
+                                        .setField(field.getMessageType().findFieldByName("day"), date.getDayOfMonth())
+                                        .build())
+                                .collect(Collectors.toList());
+                    case TIME:
+                        return struct.getStringList(field.getName()).stream()
+                                .map(LocalTime::parse)
+                                .map(time -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("hours"), time.getHour())
+                                        .setField(field.getMessageType().findFieldByName("minutes"), time.getMinute())
+                                        .setField(field.getMessageType().findFieldByName("seconds"), time.getSecond())
+                                        .setField(field.getMessageType().findFieldByName("nanos"), time.getNano())
+                                        .build())
+                                .collect(Collectors.toList());
+                    case DATETIME: {
+                        final Descriptors.FieldDescriptor timezone = field.getMessageType().findFieldByName("time_zone");
+                        return struct.getTimestampList(field.getName()).stream()
+                                .map(t -> java.time.Instant.ofEpochSecond(t.getSeconds(), t.getNanos()).atZone(ZoneId.of(ZoneOffset.UTC.getId())))
+                                .map(dt -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(timezone,
+                                                DynamicMessage.newBuilder(timezone.getMessageType())
+                                                        .setField(timezone.getMessageType().findFieldByName("id"), ZoneOffset.UTC.getId())
+                                                        .build())
+                                        .setField(field.getMessageType().findFieldByName("year"), dt.getYear())
+                                        .setField(field.getMessageType().findFieldByName("month"), dt.getMonthValue())
+                                        .setField(field.getMessageType().findFieldByName("day"), dt.getDayOfMonth())
+                                        .setField(field.getMessageType().findFieldByName("hours"), dt.getHour())
+                                        .setField(field.getMessageType().findFieldByName("minutes"), dt.getMinute())
+                                        .setField(field.getMessageType().findFieldByName("seconds"), dt.getSecond())
+                                        .build())
+                                .collect(Collectors.toList());
+                    }
+                    case TIMESTAMP:
+                        return struct.getTimestampList(field.getName()).stream()
+                                .map(timestamp -> DynamicMessage.newBuilder(field.getMessageType())
+                                        .setField(field.getMessageType().findFieldByName("seconds"), timestamp.getSeconds())
+                                        .setField(field.getMessageType().findFieldByName("nanos"), timestamp.getNanos())
+                                        .build())
+                                .collect(Collectors.toList());
+                    case ANY:
+                        return struct.getStringList(field.getName()).stream()
+                                .map(s -> Any.newBuilder().setValue(ByteString.copyFromUtf8(s)).build())
+                                .collect(Collectors.toList());
+                    case EMPTY:
+                    case NULL_VALUE:
+                        return new ArrayList<>();
+                    case CUSTOM:
+                    default:
+                        return struct.getStructList(field.getName()).stream()
+                                .map(s -> convert(field.getMessageType(), s))
+                                .collect(Collectors.toList());
+                }
+
+            }
+            default: {
+                throw new IllegalArgumentException("");
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/mercari/solution/util/converter/EntityToProtoConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/converter/EntityToProtoConverterTest.java
@@ -1,0 +1,396 @@
+package com.mercari.solution.util.converter;
+
+import com.google.datastore.v1.Entity;
+import com.google.datastore.v1.Value;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
+import com.mercari.solution.util.ResourceUtil;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+import org.apache.beam.sdk.schemas.Schema;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EntityToProtoConverterTest {
+
+    @Test
+    public void testConvert() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Schema schema = ProtoToRowConverter.convertSchema(descriptor);
+
+        final JsonFormat.TypeRegistry.Builder builder = JsonFormat.TypeRegistry.newBuilder();
+        descriptors.forEach((k, v) -> builder.add(v));
+        final JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(builder.build());
+
+        final Entity entity = ProtoToEntityConverter.convert(schema, descriptor, protoBytes, printer);
+
+        final DynamicMessage message1 = EntityToProtoConverter.convert(descriptor, entity);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertEntityValues(message1, entity, printer);
+        assertEntityValues(message2, entity, printer);
+
+        testNest(message1, entity, printer);
+        testNest(message2, entity, printer);
+    }
+
+    @Test
+    public void testConvertNull() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test_null.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Schema schema = ProtoToRowConverter.convertSchema(descriptor);
+
+        final JsonFormat.TypeRegistry.Builder builder = JsonFormat.TypeRegistry.newBuilder();
+        descriptors.forEach((k, v) -> builder.add(v));
+        final JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(builder.build());
+
+        final Entity entity = ProtoToEntityConverter.convert(schema, descriptor, protoBytes, printer);
+
+        final DynamicMessage message1 = EntityToProtoConverter.convert(descriptor, entity);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertRowNullValues(message1, printer);
+        assertRowNullValues(message2, printer);
+    }
+
+    private void testNest(final DynamicMessage message, final Entity entity, final JsonFormat.Printer printer) {
+        if(ProtoSchemaUtil.hasField(message, "child")) {
+            final Entity child = entity.getPropertiesOrThrow("child").getEntityValue();
+            final DynamicMessage childMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "child");
+            assertEntityValues(childMessage, child, printer);
+
+            final List<Entity> grandchildren = child.getPropertiesOrThrow("grandchildren").getArrayValue()
+                    .getValuesList()
+                    .stream()
+                    .map(Value::getEntityValue)
+                    .collect(Collectors.toList());
+
+            final List<DynamicMessage> grandchildrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(childMessage, "grandchildren");
+            int i = 0;
+            for(final Entity e : grandchildren) {
+                assertEntityValues(grandchildrenMessages.get(i), e, printer);
+                i++;
+            }
+
+            if(ProtoSchemaUtil.hasField(childMessage, "grandchild")) {
+                final Entity grandchild = child.getPropertiesOrThrow("grandchild").getEntityValue();
+                final DynamicMessage grandchildMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(childMessage, "grandchild");
+                assertEntityValues(grandchildMessage, grandchild, printer);
+            }
+        }
+
+        final List<Entity> children = entity.getPropertiesOrThrow("children").getArrayValue()
+                .getValuesList()
+                .stream()
+                .map(Value::getEntityValue)
+                .collect(Collectors.toList());
+        final List<DynamicMessage> childrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "children");
+        int i = 0;
+        for(final Entity e : children) {
+            assertEntityValues(childrenMessages.get(i), e, printer);
+            i++;
+        }
+    }
+
+    private void assertEntityValues(final DynamicMessage message, final Entity entity, final JsonFormat.Printer printer) {
+
+        // Build-in type
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValue", printer), entity.getPropertiesOrThrow("boolValue").getBooleanValue());
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValue", printer), entity.getPropertiesOrThrow("stringValue").getStringValue());
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8),
+                new String(entity.getPropertiesOrThrow("bytesValue").getBlobValue().toByteArray(), StandardCharsets.UTF_8));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "intValue", printer), (int)entity.getPropertiesOrThrow("intValue").getIntegerValue());
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValue", printer), entity.getPropertiesOrThrow("longValue").getIntegerValue());
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "floatValue", printer), (float)entity.getPropertiesOrThrow("floatValue").getDoubleValue());
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValue", printer), entity.getPropertiesOrThrow("doubleValue").getDoubleValue());
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "uintValue", printer), (int)entity.getPropertiesOrThrow("uintValue").getIntegerValue());
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValue", printer), entity.getPropertiesOrThrow("ulongValue").getIntegerValue());
+
+        // Google-provided type
+        Assert.assertEquals(
+                (int)((LocalDate) ProtoSchemaUtil.getValue(message, "dateValue", printer)).toEpochDay(),
+                LocalDate.parse(entity.getPropertiesOrThrow("dateValue").getStringValue()).toEpochDay());
+        Assert.assertEquals(
+                ((LocalTime) ProtoSchemaUtil.getValue(message, "timeValue", printer)).toSecondOfDay(),
+                LocalTime.parse(entity.getPropertiesOrThrow("timeValue").getStringValue()).toSecondOfDay());
+        Assert.assertEquals(
+                ((Instant) ProtoSchemaUtil.getValue(message, "datetimeValue", printer)).getMillis(),
+                Timestamps.toMillis(entity.getPropertiesOrThrow("datetimeValue").getTimestampValue()));
+        Assert.assertEquals(
+                ((Instant) ProtoSchemaUtil.getValue(message, "timestampValue", printer)).getMillis(),
+                Timestamps.toMillis(entity.getPropertiesOrThrow("timestampValue").getTimestampValue()));
+
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer),
+                entity.getPropertiesOrThrow("wrappedBoolValue").getBooleanValue());
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer),
+                entity.getPropertiesOrThrow("wrappedStringValue").getStringValue());
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8),
+                new String(entity.getPropertiesOrThrow("wrappedBytesValue").getBlobValue().toByteArray(), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer),
+                (int)entity.getPropertiesOrThrow("wrappedInt32Value").getIntegerValue());
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer),
+                entity.getPropertiesOrThrow("wrappedInt64Value").getIntegerValue());
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer),
+                (float)entity.getPropertiesOrThrow("wrappedFloatValue").getDoubleValue());
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer),
+                entity.getPropertiesOrThrow("wrappedDoubleValue").getDoubleValue());
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer),
+                (int)entity.getPropertiesOrThrow("wrappedUInt32Value").getIntegerValue());
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer),
+                entity.getPropertiesOrThrow("wrappedUInt64Value").getIntegerValue());
+
+        // Any is not supported
+
+        // Enum
+        String enumSymbol = entity.getPropertiesOrThrow("enumValue").getStringValue();
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getName(),
+                    enumSymbol);
+        } else {
+            Assert.assertEquals(ProtoSchemaUtil.getField(message, "enumValue").getEnumType().getValues().get(0).getName(), enumSymbol);
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals(ProtoSchemaUtil.getValue(message, "entityName", printer), entity.getPropertiesOrThrow("entityName").getStringValue());
+        } else {
+            Assert.assertEquals(ProtoSchemaUtil.getValue(message, "entityAge", printer), (int) entity.getPropertiesOrThrow("entityAge").getIntegerValue());
+        }
+
+        // Map is not supported
+
+        // Repeated
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValues", printer), entity.getPropertiesOrThrow("boolValues")
+                .getArrayValue().getValuesList().stream().map(Value::getBooleanValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValues", printer), entity.getPropertiesOrThrow("stringValues")
+                .getArrayValue().getValuesList().stream().map(Value::getStringValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "intValues", printer), entity.getPropertiesOrThrow("intValues")
+                .getArrayValue().getValuesList().stream().map(Value::getIntegerValue).map(Long::intValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValues", printer), entity.getPropertiesOrThrow("longValues")
+                .getArrayValue().getValuesList().stream().map(Value::getIntegerValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "floatValues", printer), entity.getPropertiesOrThrow("floatValues")
+                .getArrayValue().getValuesList().stream().map(Value::getDoubleValue).map(Double::floatValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValues", printer), entity.getPropertiesOrThrow("doubleValues")
+                .getArrayValue().getValuesList().stream().map(Value::getDoubleValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "uintValues", printer), entity.getPropertiesOrThrow("uintValues")
+                .getArrayValue().getValuesList().stream().map(Value::getIntegerValue).map(Long::intValue).collect(Collectors.toList()));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValues", printer), entity.getPropertiesOrThrow("ulongValues")
+                .getArrayValue().getValuesList().stream().map(Value::getIntegerValue).collect(Collectors.toList()));
+
+        List<DynamicMessage> list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "dateValues");
+        final List<String> dateList = entity.getPropertiesOrThrow("dateValues").getArrayValue().getValuesList()
+                .stream()
+                .map(Value::getStringValue)
+                .collect(Collectors.toList());
+        int i = 0;
+        if(ProtoSchemaUtil.hasField(message, "dateValues")) {
+            Assert.assertEquals(list.size(), dateList.size());
+            for (String date : dateList) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getEpochDay(
+                                (com.google.type.Date) (ProtoSchemaUtil.convertBuildInValue("google.type.Date", list.get(i)))),
+                        LocalDate.parse(date).toEpochDay());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<String>(), dateList);
+        }
+
+        final List<String> timeList = entity.getPropertiesOrThrow("timeValues").getArrayValue().getValuesList()
+                .stream()
+                .map(Value::getStringValue)
+                .collect(Collectors.toList());
+        if(ProtoSchemaUtil.hasField(message, "timeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timeValues");
+            Assert.assertEquals(list.size(), timeList.size());
+            i = 0;
+            for (String time : timeList) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getSecondOfDay(
+                                (com.google.type.TimeOfDay) (ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay", list.get(i)))),
+                        LocalTime.parse(time).toSecondOfDay());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<String>(), timeList);
+        }
+
+        final List<Timestamp> datetimeList = entity.getPropertiesOrThrow("datetimeValues").getArrayValue().getValuesList()
+                .stream()
+                .map(Value::getTimestampValue)
+                .collect(Collectors.toList());
+        if(ProtoSchemaUtil.hasField(message, "datetimeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "datetimeValues");
+            Assert.assertEquals(list.size(), datetimeList.size());
+            i = 0;
+            for (Timestamp datetime : datetimeList) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getEpochMillis(
+                                (com.google.type.DateTime) (ProtoSchemaUtil.convertBuildInValue("google.type.DateTime", list.get(i)))),
+                        Timestamps.toMillis(datetime));
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Timestamp>(), datetimeList);
+        }
+
+        final List<Timestamp> timestampList = entity.getPropertiesOrThrow("timestampValues").getArrayValue().getValuesList()
+                .stream()
+                .map(Value::getTimestampValue)
+                .collect(Collectors.toList());
+        if(ProtoSchemaUtil.hasField(message, "timestampValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timestampValues");
+            Assert.assertEquals(list.size(), timestampList.size());
+            i = 0;
+            for (Timestamp timestamp : timestampList) {
+                Assert.assertEquals(
+                        Timestamps.toMicros(
+                                (com.google.protobuf.Timestamp) (ProtoSchemaUtil.convertBuildInValue("google.protobuf.Timestamp", list.get(i)))),
+                        Timestamps.toMicros(timestamp));
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Timestamp>(), timestampList);
+        }
+
+        final List<String> enumList = entity.getPropertiesOrThrow("enumValues").getArrayValue().getValuesList()
+                .stream()
+                .map(Value::getStringValue)
+                .collect(Collectors.toList());
+        if(ProtoSchemaUtil.hasField(message, "enumValues")) {
+            List<Descriptors.EnumValueDescriptor> enums = (List<Descriptors.EnumValueDescriptor>) ProtoSchemaUtil.getFieldValue(message, "enumValues");
+            Assert.assertEquals(enums.size(), enumList.size());
+            i = 0;
+            for(String enumValue : enumList) {
+                Assert.assertEquals(
+                        enums.get(i).getName(),
+                        enumValue);
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<String>(), enumList);
+        }
+
+    }
+
+    private void assertRowNullValues(final DynamicMessage message, final JsonFormat.Printer printer) {
+        // Build-in type
+        Assert.assertEquals(false, ProtoSchemaUtil.getValue(message, "boolValue", printer));
+        Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "stringValue", printer));
+        Assert.assertEquals("", new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "intValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "longValue", printer));
+        Assert.assertEquals(0F, ProtoSchemaUtil.getValue(message, "floatValue", printer));
+        Assert.assertEquals(0D, ProtoSchemaUtil.getValue(message, "doubleValue", printer));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "uintValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "ulongValue", printer));
+
+        // Google-provided type
+        if(ProtoSchemaUtil.hasField(message,"dateValue")) {
+            Assert.assertEquals(
+                    LocalDate.of(1,1,1).toEpochDay(),
+                    ProtoSchemaUtil.getEpochDay(
+                            (com.google.type.Date)(ProtoSchemaUtil.convertBuildInValue("google.type.Date",
+                                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "dateValue"))))
+            );
+        }
+
+        // TODO Somehow it becomes null when it is 00:00:00.
+        /*
+        if(ProtoSchemaUtil.hasField(message,"timeValue")) {
+            Assert.assertEquals(
+                    LocalTime.of(0,0,0).toSecondOfDay(),
+                    ProtoSchemaUtil.getSecondOfDay((com.google.type.TimeOfDay)(ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timeValue")))));
+        }
+        */
+        if(ProtoSchemaUtil.hasField(message,"datetimeValue")) {
+            Assert.assertEquals(
+                    -62135596800000L,
+                    ProtoSchemaUtil.getEpochMillis((com.google.type.DateTime)(ProtoSchemaUtil.convertBuildInValue("google.type.DateTime",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "datetimeValue")))));
+        }
+
+        Assert.assertEquals(
+                false,
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer));
+        Assert.assertEquals(
+                "",
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer));
+        Assert.assertEquals(
+                "",
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer));
+        Assert.assertEquals(
+                0F,
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer));
+        Assert.assertEquals(
+                0D,
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer));
+
+        // Enum
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    0,
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getIndex());
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "entityName", printer));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "entityAge", printer));
+        }
+
+        // Repeated
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "boolValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "stringValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "intValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "longValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "floatValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "doubleValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "uintValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "ulongValues", printer));
+    }
+
+}

--- a/src/test/java/com/mercari/solution/util/converter/RecordToProtoConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/converter/RecordToProtoConverterTest.java
@@ -1,0 +1,354 @@
+package com.mercari.solution.util.converter;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
+import com.mercari.solution.util.ResourceUtil;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.schemas.logicaltypes.Date;
+import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class RecordToProtoConverterTest {
+
+    @Test
+    public void testConvert() {
+
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Schema schema = ProtoToRecordConverter.convertSchema(descriptor);
+
+        final JsonFormat.Printer printer = ProtoSchemaUtil.createJsonPrinter(descriptors);
+
+        final GenericRecord record = ProtoToRecordConverter.convert(schema, descriptor, protoBytes, printer);
+        final DynamicMessage message1 = RecordToProtoConverter.convert(descriptor, record);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertRecordValues(message1, record, printer);
+        assertRecordValues(message2, record, printer);
+
+        testNest(message1, record, printer);
+        testNest(message2, record, printer);
+    }
+
+    @Test
+    public void testConvertNull() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test_null.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Schema schema = ProtoToRecordConverter.convertSchema(descriptor);
+
+        final JsonFormat.Printer printer = ProtoSchemaUtil.createJsonPrinter(descriptors);
+
+        final GenericRecord record = ProtoToRecordConverter.convert(schema, descriptor, protoBytes, printer);
+        final DynamicMessage message1 = RecordToProtoConverter.convert(descriptor, record);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertRecordNullValues(message1, printer);
+        assertRecordNullValues(message2, printer);
+    }
+
+    private void testNest(final DynamicMessage message, final GenericRecord record, final JsonFormat.Printer printer) {
+        if(ProtoSchemaUtil.hasField(message, "child")) {
+            final GenericRecord child = (GenericRecord) record.get("child");
+            final DynamicMessage childMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "child");
+            assertRecordValues(childMessage, child, printer);
+
+            final List<GenericRecord> grandchildren = (List<GenericRecord>)child.get("grandchildren");
+            final List<DynamicMessage> grandchildrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(childMessage, "grandchildren");
+            int i = 0;
+            for(final GenericRecord r : grandchildren) {
+                assertRecordValues(grandchildrenMessages.get(i), r, printer);
+                i++;
+            }
+
+            if(ProtoSchemaUtil.hasField(childMessage, "grandchild")) {
+                final GenericRecord grandchild = (GenericRecord) child.get("grandchild");
+                final DynamicMessage grandchildMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(childMessage, "grandchild");
+                assertRecordValues(grandchildMessage, grandchild, printer);
+            }
+        }
+
+        final List<GenericRecord> children = (List<GenericRecord>)record.get("children");
+        final List<DynamicMessage> childrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "children");
+        int i = 0;
+        for(final GenericRecord r : children) {
+            assertRecordValues(childrenMessages.get(i), r, printer);
+            i++;
+        }
+    }
+
+    private void assertRecordValues(final DynamicMessage message, final GenericRecord record, final JsonFormat.Printer printer) {
+
+        // Build-in type
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValue", printer), record.get("boolValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValue", printer), record.get("stringValue"));
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8),
+                new String(((ByteBuffer)record.get("bytesValue")).array(), StandardCharsets.UTF_8));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "intValue", printer), record.get("intValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValue", printer), record.get("longValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "floatValue", printer), record.get("floatValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValue", printer), record.get("doubleValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "uintValue", printer), record.get("uintValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValue", printer), record.get("ulongValue"));
+
+        // Google-provided type
+        Assert.assertEquals(
+                (int)((LocalDate) ProtoSchemaUtil.getValue(message, "dateValue", printer)).toEpochDay(),
+                record.get("dateValue"));
+        Assert.assertEquals(
+                ((LocalTime) ProtoSchemaUtil.getValue(message, "timeValue", printer)).toSecondOfDay() * 1000_000L,
+                record.get("timeValue"));
+        Assert.assertEquals(
+                ((Instant) ProtoSchemaUtil.getValue(message, "datetimeValue", printer)).getMillis() * 1000,
+                record.get("datetimeValue"));
+        Assert.assertEquals(
+                ((Instant) ProtoSchemaUtil.getValue(message, "timestampValue", printer)).getMillis() * 1000,
+                record.get("timestampValue"));
+
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer),
+                record.get("wrappedBoolValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer),
+                record.get("wrappedStringValue"));
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8),
+                new String(((ByteBuffer)record.get("wrappedBytesValue")).array(), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer),
+                record.get("wrappedInt32Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer),
+                record.get("wrappedInt64Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer),
+                record.get("wrappedFloatValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer),
+                record.get("wrappedDoubleValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer),
+                record.get("wrappedUInt32Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer),
+                record.get("wrappedUInt64Value"));
+
+        // Any not supported
+
+        // Enum
+        GenericData.EnumSymbol enumSymbol = (GenericData.EnumSymbol)record.get("enumValue");
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getIndex(),
+                    enumSymbol.getSchema().getEnumOrdinal(record.get("enumValue").toString()));
+        } else {
+            Assert.assertEquals(0, enumSymbol.getSchema().getEnumOrdinal(record.get("enumValue").toString()));
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals(ProtoSchemaUtil.getValue(message, "entityName", printer), record.get("entityName"));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            Assert.assertEquals(ProtoSchemaUtil.getValue(message, "entityAge", printer), record.get("entityAge"));
+        }
+
+        // Map not supported
+
+        // Repeated
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValues", printer), record.get("boolValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValues", printer), record.get("stringValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "intValues", printer), record.get("intValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValues", printer), record.get("longValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "floatValues", printer), record.get("floatValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValues", printer), record.get("doubleValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "uintValues", printer), record.get("uintValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValues", printer), record.get("ulongValues"));
+
+        List<DynamicMessage> list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "dateValues");
+        int i = 0;
+        if(ProtoSchemaUtil.hasField(message, "dateValues")) {
+            Assert.assertEquals(list.size(), ((List)record.get("dateValues")).size());
+            for (int epochDay : (List<Integer>)record.get("dateValues")) {
+                Assert.assertEquals(
+                        (int) ProtoSchemaUtil.getEpochDay(
+                                (com.google.type.Date) (ProtoSchemaUtil.convertBuildInValue("google.type.Date", list.get(i)))),
+                        epochDay);
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Date>(), record.get("dateValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timeValues");
+            Assert.assertEquals(list.size(), ((List)record.get("timeValues")).size());
+            i = 0;
+            for (long microSecondOfDay : (List<Long>)record.get("timeValues")) {
+                Assert.assertEquals(
+                        1000_000 * ProtoSchemaUtil.getSecondOfDay(
+                                (com.google.type.TimeOfDay) (ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay", list.get(i)))),
+                        microSecondOfDay);
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<LocalTime>(), record.get("timeValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "datetimeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "datetimeValues");
+            Assert.assertEquals(list.size(), ((List)record.get("datetimeValues")).size());
+            i = 0;
+            for (long epochMicros : (List<Long>)record.get("datetimeValues")) {
+                Assert.assertEquals(
+                        1000 * ProtoSchemaUtil.getEpochMillis(
+                                (com.google.type.DateTime) (ProtoSchemaUtil.convertBuildInValue("google.type.DateTime", list.get(i)))),
+                        epochMicros);
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Instant>(), record.get("datetimeValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timestampValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timestampValues");
+            Assert.assertEquals(list.size(), ((List)record.get("timestampValues")).size());
+            i = 0;
+            for (long epochMicros : (List<Long>)record.get("timestampValues")) {
+                Assert.assertEquals(
+                        Timestamps.toMicros(
+                                (com.google.protobuf.Timestamp) (ProtoSchemaUtil.convertBuildInValue("google.protobuf.Timestamp", list.get(i)))),
+                        epochMicros);
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Instant>(), record.get("timestampValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "enumValues")) {
+            List<Descriptors.EnumValueDescriptor> enums = (List<Descriptors.EnumValueDescriptor>) ProtoSchemaUtil.getFieldValue(message, "enumValues");
+            Assert.assertEquals(enums.size(), ((List)record.get("enumValues")).size());
+            i = 0;
+            for(var enumValue : (List<GenericData.EnumSymbol>)record.get("enumValues")) {
+                Assert.assertEquals(
+                        enums.get(i).getName(),
+                        enumValue.toString());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<EnumerationType.Value>(), record.get("enumValues"));
+        }
+    }
+
+    private void assertRecordNullValues(final DynamicMessage message, final JsonFormat.Printer printer) {
+        // Build-in type
+        Assert.assertEquals(false, ProtoSchemaUtil.getValue(message, "boolValue", printer));
+        Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "stringValue", printer));
+        Assert.assertEquals("", new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "intValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "longValue", printer));
+        Assert.assertEquals(0F, ProtoSchemaUtil.getValue(message, "floatValue", printer));
+        Assert.assertEquals(0D, ProtoSchemaUtil.getValue(message, "doubleValue", printer));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "uintValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "ulongValue", printer));
+
+        // Google-provided type
+        if(ProtoSchemaUtil.hasField(message,"dateValue")) {
+            Assert.assertEquals(
+                    LocalDate.of(1,1,1).toEpochDay(),
+                    ProtoSchemaUtil.getEpochDay(
+                            (com.google.type.Date)(ProtoSchemaUtil.convertBuildInValue("google.type.Date",
+                                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "dateValue"))))
+            );
+        }
+
+        // TODO Somehow it becomes null when it is 00:00:00.
+        /*
+        if(ProtoSchemaUtil.hasField(message,"timeValue")) {
+            Assert.assertEquals(
+                    LocalTime.of(0,0,0).toSecondOfDay(),
+                    ProtoSchemaUtil.getSecondOfDay((com.google.type.TimeOfDay)(ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timeValue")))));
+        }
+        */
+        if(ProtoSchemaUtil.hasField(message,"datetimeValue")) {
+            Assert.assertEquals(
+                    -62135596800000L,
+                    ProtoSchemaUtil.getEpochMillis((com.google.type.DateTime)(ProtoSchemaUtil.convertBuildInValue("google.type.DateTime",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "datetimeValue")))));
+        }
+
+        Assert.assertEquals(
+                false,
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer));
+        Assert.assertEquals(
+                "",
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer));
+        Assert.assertEquals(
+                "",
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer));
+        Assert.assertEquals(
+                0F,
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer));
+        Assert.assertEquals(
+                0D,
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer));
+
+        // Enum
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    0,
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getIndex());
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "entityName", printer));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "entityAge", printer));
+        }
+
+        // Repeated
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "boolValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "stringValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "intValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "longValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "floatValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "doubleValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "uintValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "ulongValues", printer));
+    }
+
+}

--- a/src/test/java/com/mercari/solution/util/converter/RowToProtoConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/converter/RowToProtoConverterTest.java
@@ -1,0 +1,366 @@
+package com.mercari.solution.util.converter;
+
+import com.google.protobuf.*;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
+import com.mercari.solution.util.ResourceUtil;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.logicaltypes.Date;
+import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class RowToProtoConverterTest {
+
+    @Test
+    public void testConvert() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Schema schema = ProtoToRowConverter.convertSchema(descriptor);
+
+        final JsonFormat.TypeRegistry.Builder builder = JsonFormat.TypeRegistry.newBuilder();
+        descriptors.forEach((k, v) -> builder.add(v));
+        final JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(builder.build());
+
+        final Row row = ProtoToRowConverter.convert(schema, descriptor, protoBytes, printer);
+
+        final DynamicMessage message1 = RowToProtoConverter.convert(descriptor, row);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertRowValues(message1, row, printer);
+        assertRowValues(message2, row, printer);
+
+        testNest(message1, row, printer);
+        testNest(message2, row, printer);
+    }
+
+    @Test
+    public void testConvertNull() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test_null.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Schema schema = ProtoToRowConverter.convertSchema(descriptor);
+
+        final JsonFormat.TypeRegistry.Builder builder = JsonFormat.TypeRegistry.newBuilder();
+        descriptors.forEach((k, v) -> builder.add(v));
+        final JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(builder.build());
+
+        final Row row = ProtoToRowConverter.convert(schema, descriptor, protoBytes, printer);
+
+        final DynamicMessage message1 = RowToProtoConverter.convert(descriptor, row);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertRowNullValues(message1, printer);
+        assertRowNullValues(message2, printer);
+    }
+
+    private void testNest(final DynamicMessage message, final Row row, final JsonFormat.Printer printer) {
+        if(ProtoSchemaUtil.hasField(message, "child")) {
+            final Row child = row.getRow("child");
+            final DynamicMessage childMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "child");
+            assertRowValues(childMessage, child, printer);
+
+            final Collection<Row> grandchildren = child.getArray("grandchildren");
+            final List<DynamicMessage> grandchildrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(childMessage, "grandchildren");
+            int i = 0;
+            for(final Row c : grandchildren) {
+                assertRowValues(grandchildrenMessages.get(i), c, printer);
+                i++;
+            }
+
+            if(ProtoSchemaUtil.hasField(childMessage, "grandchild")) {
+                final Row grandchild = child.getRow("grandchild");
+                final DynamicMessage grandchildMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(childMessage, "grandchild");
+                assertRowValues(grandchildMessage, grandchild, printer);
+            }
+        }
+
+        final Collection<Row> children = row.getArray("children");
+        final List<DynamicMessage> childrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "children");
+        int i = 0;
+        for(final Row c : children) {
+            assertRowValues(childrenMessages.get(i), c, printer);
+            i++;
+        }
+    }
+
+    private void assertRowValues(final DynamicMessage message, final Row row, final JsonFormat.Printer printer) {
+
+        // Build-in type
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValue", printer), row.getBoolean("boolValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValue", printer), row.getString("stringValue"));
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8),
+                new String(row.getBytes("bytesValue"), StandardCharsets.UTF_8));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "intValue", printer), row.getInt32("intValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValue", printer), row.getInt64("longValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "floatValue", printer), row.getFloat("floatValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValue", printer), row.getDouble("doubleValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "uintValue", printer), row.getInt32("uintValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValue", printer), row.getInt64("ulongValue"));
+
+        // Google-provided type
+        if(ProtoSchemaUtil.hasField(message,"dateValue")) {
+            Assert.assertEquals(
+                    ProtoSchemaUtil.getEpochDay(
+                            (com.google.type.Date)(ProtoSchemaUtil.convertBuildInValue("google.type.Date",
+                                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "dateValue")))),
+                    ((LocalDate)row.getValue("dateValue")).toEpochDay());
+        }
+        if(ProtoSchemaUtil.hasField(message,"timeValue")) {
+            Assert.assertEquals(
+                    ProtoSchemaUtil.getSecondOfDay((com.google.type.TimeOfDay)(ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timeValue")))),
+                    ((LocalTime)row.getValue("timeValue")).toSecondOfDay());
+        }
+
+        if(ProtoSchemaUtil.hasField(message,"datetimeValue")) {
+            Assert.assertEquals(
+                    ProtoSchemaUtil.getEpochMillis((com.google.type.DateTime)(ProtoSchemaUtil.convertBuildInValue("google.type.DateTime",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "datetimeValue")))),
+                    ((Instant)row.getValue("datetimeValue")).getMillis());
+        }
+
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer),
+                row.getBoolean("wrappedBoolValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer),
+                row.getString("wrappedStringValue"));
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8),
+                new String(row.getBytes("wrappedBytesValue"), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer),
+                row.getInt32("wrappedInt32Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer),
+                row.getInt64("wrappedInt64Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer),
+                row.getFloat("wrappedFloatValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer),
+                row.getDouble("wrappedDoubleValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer),
+                row.getInt32("wrappedUInt32Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer),
+                row.getInt64("wrappedUInt64Value"));
+
+        // Any not support
+
+        // Enum
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getIndex(),
+                    ((EnumerationType.Value)row.getValue("enumValue")).getValue());
+        } else {
+            Assert.assertEquals(0, ((EnumerationType.Value)row.getValue("enumValue")).getValue());
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals(ProtoSchemaUtil.getValue(message, "entityName", printer), row.getString("entityName"));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            Assert.assertEquals(ProtoSchemaUtil.getValue(message, "entityAge", printer), row.getInt32("entityAge"));
+        }
+
+        // Map not support
+
+        // Repeated
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValues", printer), row.getArray("boolValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValues", printer), row.getArray("stringValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "intValues", printer), row.getArray("intValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValues", printer), row.getArray("longValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "floatValues", printer), row.getArray("floatValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValues", printer), row.getArray("doubleValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "uintValues", printer), row.getArray("uintValues"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValues", printer), row.getArray("ulongValues"));
+
+        List<DynamicMessage> list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "dateValues");
+        int i = 0;
+        if(ProtoSchemaUtil.hasField(message, "dateValues")) {
+            Assert.assertEquals(list.size(), row.getArray("dateValues").size());
+
+            for (var localDate : row.getArray("dateValues")) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getEpochDay(
+                                (com.google.type.Date) (ProtoSchemaUtil.convertBuildInValue("google.type.Date", list.get(i)))),
+                        ((LocalDate) localDate).toEpochDay());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Date>(), row.getArray("dateValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timeValues");
+            Assert.assertEquals(list.size(), row.getArray("timeValues").size());
+            i = 0;
+            for (var localTime : row.getArray("timeValues")) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getSecondOfDay(
+                                (com.google.type.TimeOfDay) (ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay", list.get(i)))),
+                        ((LocalTime) localTime).toSecondOfDay());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<LocalTime>(), row.getArray("timeValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "datetimeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "datetimeValues");
+            Assert.assertEquals(list.size(), row.getArray("datetimeValues").size());
+            i = 0;
+            for (var localDateTime : row.getArray("datetimeValues")) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getEpochMillis(
+                                (com.google.type.DateTime) (ProtoSchemaUtil.convertBuildInValue("google.type.DateTime", list.get(i)))),
+                        ((Instant) localDateTime).getMillis());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Instant>(), row.getArray("datetimeValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timestampValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timestampValues");
+            Assert.assertEquals(list.size(), row.getArray("timestampValues").size());
+            i = 0;
+            for (var instant : row.getArray("timestampValues")) {
+                Assert.assertEquals(
+                        Timestamps.toMillis(
+                                (com.google.protobuf.Timestamp) (ProtoSchemaUtil.convertBuildInValue("google.protobuf.Timestamp", list.get(i)))),
+                        ((Instant) instant).getMillis());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<Instant>(), row.getArray("timestampValues"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "enumValues")) {
+            List<Descriptors.EnumValueDescriptor> enums = (List<Descriptors.EnumValueDescriptor>) ProtoSchemaUtil.getFieldValue(message, "enumValues");
+            Assert.assertEquals(enums.size(), row.getArray("enumValues").size());
+            i = 0;
+            for(var json : row.getArray("enumValues")) {
+                Assert.assertEquals(
+                        enums.get(i).getIndex(),
+                        ((EnumerationType.Value)json).getValue());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(new ArrayList<EnumerationType.Value>(), row.getArray("enumValues"));
+        }
+
+    }
+
+    private void assertRowNullValues(final DynamicMessage message, final JsonFormat.Printer printer) {
+        // Build-in type
+        Assert.assertEquals(false, ProtoSchemaUtil.getValue(message, "boolValue", printer));
+        Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "stringValue", printer));
+        Assert.assertEquals("", new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "intValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "longValue", printer));
+        Assert.assertEquals(0F, ProtoSchemaUtil.getValue(message, "floatValue", printer));
+        Assert.assertEquals(0D, ProtoSchemaUtil.getValue(message, "doubleValue", printer));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "uintValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "ulongValue", printer));
+
+        // Google-provided type
+        if(ProtoSchemaUtil.hasField(message,"dateValue")) {
+            Assert.assertEquals(
+                    LocalDate.of(1,1,1).toEpochDay(),
+                    ProtoSchemaUtil.getEpochDay(
+                            (com.google.type.Date)(ProtoSchemaUtil.convertBuildInValue("google.type.Date",
+                                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "dateValue"))))
+                    );
+        }
+
+        // TODO Somehow it becomes null when it is 00:00:00.
+        /*
+        if(ProtoSchemaUtil.hasField(message,"timeValue")) {
+            Assert.assertEquals(
+                    LocalTime.of(0,0,0).toSecondOfDay(),
+                    ProtoSchemaUtil.getSecondOfDay((com.google.type.TimeOfDay)(ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timeValue")))));
+        }
+        */
+        if(ProtoSchemaUtil.hasField(message,"datetimeValue")) {
+            Assert.assertEquals(
+                    -62135596800000L,
+                    ProtoSchemaUtil.getEpochMillis((com.google.type.DateTime)(ProtoSchemaUtil.convertBuildInValue("google.type.DateTime",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "datetimeValue")))));
+        }
+
+        Assert.assertEquals(
+                false,
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer));
+        Assert.assertEquals(
+                "",
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer));
+        Assert.assertEquals(
+                "",
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer));
+        Assert.assertEquals(
+                0F,
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer));
+        Assert.assertEquals(
+                0D,
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer));
+
+        // Enum
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    0,
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getIndex());
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "entityName", printer));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "entityAge", printer));
+        }
+
+        // Repeated
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "boolValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "stringValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "intValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "longValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "floatValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "doubleValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "uintValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "ulongValues", printer));
+    }
+
+}

--- a/src/test/java/com/mercari/solution/util/converter/StructToProtoConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/converter/StructToProtoConverterTest.java
@@ -1,0 +1,387 @@
+package com.mercari.solution.util.converter;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
+import com.mercari.solution.util.ResourceUtil;
+import com.mercari.solution.util.schema.ProtoSchemaUtil;
+import com.mercari.solution.util.schema.StructSchemaUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class StructToProtoConverterTest {
+
+    private static final double DELTA = 1e-15;
+
+    @Test
+    public void testConvert() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Type type = ProtoToStructConverter.convertSchema(descriptor);
+
+        final JsonFormat.TypeRegistry.Builder builder = JsonFormat.TypeRegistry.newBuilder();
+        descriptors.forEach((k, v) -> builder.add(v));
+        final JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(builder.build());
+
+        final Struct struct = ProtoToStructConverter.convert(type, descriptor, protoBytes, printer);
+
+        final DynamicMessage message1 = StructToProtoConverter.convert(descriptor, struct);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertStructValues(message1, struct, printer);
+        assertStructValues(message2, struct, printer);
+
+        testNest(message1, struct, printer);
+        testNest(message2, struct, printer);
+    }
+
+    @Test
+    public void testConvertNull() {
+        final byte[] descBytes = ResourceUtil.getResourceFileAsBytes("schema/test.desc");
+        final byte[] protoBytes = ResourceUtil.getResourceFileAsBytes("data/test_null.pb");
+
+        final Map<String, Descriptors.Descriptor> descriptors = ProtoSchemaUtil.getDescriptors(descBytes);
+        final Descriptors.Descriptor descriptor = descriptors.get("com.mercari.solution.entity.TestMessage");
+        final Type type = ProtoToStructConverter.convertSchema(descriptor);
+
+        final JsonFormat.TypeRegistry.Builder builder = JsonFormat.TypeRegistry.newBuilder();
+        descriptors.forEach((k, v) -> builder.add(v));
+        final JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(builder.build());
+
+        final Struct struct = ProtoToStructConverter.convert(type, descriptor, protoBytes, printer);
+
+        final DynamicMessage message1 = StructToProtoConverter.convert(descriptor, struct);
+        final DynamicMessage message2 = ProtoSchemaUtil.convert(descriptor, message1.toByteArray());
+
+        assertRowNullValues(message1, printer);
+        assertRowNullValues(message2, printer);
+    }
+
+    private void testNest(final DynamicMessage message, final Struct struct, final JsonFormat.Printer printer) {
+        if(ProtoSchemaUtil.hasField(message, "child")) {
+            final Struct child = (Struct) StructSchemaUtil.getValue(struct, "child");
+            final DynamicMessage childMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "child");
+            assertStructValues(childMessage, child, printer);
+
+            final List<Struct> grandchildren = child.getStructList("grandchildren");
+            final List<DynamicMessage> grandchildrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(childMessage, "grandchildren");
+            int i = 0;
+            for(final Struct s : grandchildren) {
+                assertStructValues(grandchildrenMessages.get(i), s, printer);
+                i++;
+            }
+
+            if(ProtoSchemaUtil.hasField(childMessage, "grandchild")) {
+                final Struct grandchild = (Struct)StructSchemaUtil.getValue(child, "grandchild");
+                final DynamicMessage grandchildMessage = (DynamicMessage) ProtoSchemaUtil.getFieldValue(childMessage, "grandchild");
+                assertStructValues(grandchildMessage, grandchild, printer);
+            }
+        }
+
+        final List<Struct> children = struct.getStructList("children");
+        final List<DynamicMessage> childrenMessages = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "children");
+        int i = 0;
+        for(final Struct s : children) {
+            assertStructValues(childrenMessages.get(i), s, printer);
+            i++;
+        }
+    }
+
+    private void assertStructValues(final DynamicMessage message, final Struct struct, final JsonFormat.Printer printer) {
+
+        // Build-in type
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "boolValue", printer), struct.getBoolean("boolValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "stringValue", printer), struct.getString("stringValue"));
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8),
+                new String(struct.getBytes("bytesValue").toByteArray(), StandardCharsets.UTF_8));
+        Assert.assertEquals(((Integer) ProtoSchemaUtil.getValue(message, "intValue", printer)).intValue(), struct.getLong("intValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "longValue", printer), struct.getLong("longValue"));
+        Assert.assertEquals(((Float) ProtoSchemaUtil.getValue(message, "floatValue", printer)).doubleValue(), struct.getDouble("floatValue"), DELTA);
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "doubleValue", printer), struct.getDouble("doubleValue"));
+        Assert.assertEquals(((Integer) ProtoSchemaUtil.getValue(message, "uintValue", printer)).longValue(), struct.getLong("uintValue"));
+        Assert.assertEquals(ProtoSchemaUtil.getValue(message, "ulongValue", printer), struct.getLong("ulongValue"));
+
+        // Google-provided type
+        if(ProtoSchemaUtil.hasField(message, "dateValue")) {
+            Assert.assertEquals(
+                    ProtoSchemaUtil.getEpochDay(
+                            (com.google.type.Date)(ProtoSchemaUtil.convertBuildInValue("google.type.Date",
+                                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "dateValue")))),
+                    StructSchemaUtil.getEpochDay(struct.getDate("dateValue")));
+        } else {
+            Assert.assertEquals(Date.fromYearMonthDay(1,1,1), struct.getDate("dateValue"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timeValue")) {
+            var timeOfDay = ((com.google.type.TimeOfDay) (ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay",
+                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timeValue"))));
+            Assert.assertEquals(
+                    String.format("%02d:%02d:%02d", timeOfDay.getHours(), timeOfDay.getMinutes(), timeOfDay.getSeconds()),
+                    (struct.getString("timeValue")));
+        } else {
+            Assert.assertEquals("00:00:00", struct.getString("timeValue"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "datetimeValue")) {
+            Assert.assertEquals(
+                    ProtoSchemaUtil.getEpochMillis((com.google.type.DateTime) (ProtoSchemaUtil.convertBuildInValue("google.type.DateTime",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "datetimeValue")))),
+                    (Timestamps.toMillis(struct.getTimestamp("datetimeValue").toProto())));
+        } else {
+            Assert.assertEquals(Timestamp.parseTimestamp("0001-01-01T00:00:00Z"), struct.getTimestamp("datetimeValue"));
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timestampValue")) {
+            Assert.assertEquals(
+                    Timestamps.toMillis((com.google.protobuf.Timestamp) (ProtoSchemaUtil.convertBuildInValue("google.protobuf.Timestamp",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timestampValue")))),
+                    (Timestamps.toMillis(struct.getTimestamp("timestampValue").toProto())));
+        } else {
+            Assert.assertEquals(Timestamp.parseTimestamp("0001-01-01T00:00:00Z"), struct.getTimestamp("timestampValue"));
+        }
+
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer),
+                struct.getBoolean("wrappedBoolValue"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer),
+                struct.getString("wrappedStringValue"));
+        Assert.assertEquals(
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8),
+                new String(struct.getBytes("wrappedBytesValue").toByteArray(), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                ((Integer) ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer)).longValue(),
+                struct.getLong("wrappedInt32Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer),
+                struct.getLong("wrappedInt64Value"));
+        Assert.assertEquals(
+                ((Float) ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer)).doubleValue(),
+                struct.getDouble("wrappedFloatValue"), DELTA);
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer),
+                struct.getDouble("wrappedDoubleValue"));
+        Assert.assertEquals(
+                ((Integer) ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer)).longValue(),
+                struct.getLong("wrappedUInt32Value"));
+        Assert.assertEquals(
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer),
+                struct.getLong("wrappedUInt64Value"));
+
+        // Any is not supported
+
+        // Enum
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getName(), struct.getString("enumValue"));
+        } else {
+            Assert.assertEquals(ProtoSchemaUtil.getField(message, "enumValue").getEnumType().getValues().get(0).getName(), struct.getString("enumValue"));
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            final Object entityName = ProtoSchemaUtil.getFieldValue(message, "entityName");
+            Assert.assertEquals(entityName == null ? "" : entityName, struct.getString("entityName"));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            final Object entityAge  = ProtoSchemaUtil.getFieldValue(message, "entityAge");
+            Assert.assertEquals(entityAge == null ? 0L : ((Integer) ProtoSchemaUtil.getFieldValue(message, "entityAge")).longValue(), struct.getLong("entityAge"));
+        }
+
+        // Map is not supported
+
+        // Repeated
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "boolValues")).orElse(new ArrayList<>()), struct.getBooleanList("boolValues"));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "stringValues")).orElse(new ArrayList<>()), struct.getStringList("stringValues"));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "intValues")).orElse(new ArrayList<>()), struct.getLongList("intValues").stream()
+                .map(Long::intValue).collect(Collectors.toList()));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "longValues")).orElse(new ArrayList<>()), struct.getLongList("longValues"));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "floatValues")).orElse(new ArrayList<>()), struct.getDoubleList("floatValues").stream()
+                .map(Double::floatValue).collect(Collectors.toList()));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "doubleValues")).orElse(new ArrayList<>()), struct.getDoubleList("doubleValues"));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "uintValues")).orElse(new ArrayList<>()), struct.getLongList("uintValues").stream()
+                .map(Long::intValue).collect(Collectors.toList()));
+        Assert.assertEquals(Optional.ofNullable(ProtoSchemaUtil.getFieldValue(message, "ulongValues")).orElse(new ArrayList<>()), struct.getLongList("ulongValues"));
+
+        List<DynamicMessage> list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "dateValues");
+        int i = 0;
+        if(ProtoSchemaUtil.hasField(message, "dateValues")) {
+            Assert.assertEquals(list.size(), struct.getDateList("dateValues").size());
+
+            for (var date : struct.getDateList("dateValues")) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getEpochDay(
+                                (com.google.type.Date) (ProtoSchemaUtil.convertBuildInValue("google.type.Date", list.get(i)))),
+                        StructSchemaUtil.getEpochDay(date));
+                i++;
+            }
+        } else {
+            Assert.assertEquals(0, struct.getDateList("dateValues").size());
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timeValues");
+            Assert.assertEquals(list.size(), struct.getStringList("timeValues").size());
+            i = 0;
+            for (var localTime : struct.getStringList("timeValues")) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getSecondOfDay(
+                                (com.google.type.TimeOfDay) (ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay", list.get(i)))),
+                        LocalTime.parse(localTime).toSecondOfDay());
+                i++;
+            }
+        } else {
+            Assert.assertEquals(0, struct.getStringList("timeValues").size());
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "datetimeValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "datetimeValues");
+            Assert.assertEquals(list.size(), struct.getTimestampList("datetimeValues").size());
+            i = 0;
+            for (var instant : struct.getTimestampList("datetimeValues")) {
+                Assert.assertEquals(
+                        ProtoSchemaUtil.getEpochMillis(
+                                (com.google.type.DateTime) (ProtoSchemaUtil.convertBuildInValue("google.type.DateTime", list.get(i)))),
+                        Timestamps.toMillis(instant.toProto()));
+                i++;
+            }
+        } else {
+            Assert.assertEquals(0, struct.getTimestampList("datetimeValues").size());
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "timestampValues")) {
+            list = (List<DynamicMessage>) ProtoSchemaUtil.getFieldValue(message, "timestampValues");
+            Assert.assertEquals(list.size(), struct.getTimestampList("timestampValues").size());
+            i = 0;
+            for (var instant : struct.getTimestampList("timestampValues")) {
+                Assert.assertEquals(
+                        Timestamps.toMillis(
+                                (com.google.protobuf.Timestamp) (ProtoSchemaUtil.convertBuildInValue("google.protobuf.Timestamp", list.get(i)))),
+                        Timestamps.toMillis(instant.toProto()));
+                i++;
+            }
+        } else {
+            Assert.assertEquals(0, struct.getTimestampList("timestampValues").size());
+        }
+
+        if(ProtoSchemaUtil.hasField(message, "enumValues")) {
+            List<Descriptors.EnumValueDescriptor> enums = (List<Descriptors.EnumValueDescriptor>) ProtoSchemaUtil.getFieldValue(message, "enumValues");
+            Assert.assertEquals(enums.size(), struct.getStringList("enumValues").size());
+            i = 0;
+            for(var e : struct.getStringList("enumValues")) {
+                Assert.assertEquals(
+                        enums.get(i).getName(),
+                        e);
+                i++;
+            }
+        } else {
+            Assert.assertEquals(0, struct.getStringList("enumValues").size());
+        }
+
+    }
+
+    private void assertRowNullValues(final DynamicMessage message, final JsonFormat.Printer printer) {
+        // Build-in type
+        Assert.assertEquals(false, ProtoSchemaUtil.getValue(message, "boolValue", printer));
+        Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "stringValue", printer));
+        Assert.assertEquals("", new String((byte[]) ProtoSchemaUtil.getValue(message, "bytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "intValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "longValue", printer));
+        Assert.assertEquals(0F, ProtoSchemaUtil.getValue(message, "floatValue", printer));
+        Assert.assertEquals(0D, ProtoSchemaUtil.getValue(message, "doubleValue", printer));
+        Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "uintValue", printer));
+        Assert.assertEquals(0L, ProtoSchemaUtil.getValue(message, "ulongValue", printer));
+
+        // Google-provided type
+        if(ProtoSchemaUtil.hasField(message,"dateValue")) {
+            Assert.assertEquals(
+                    LocalDate.of(1,1,1).toEpochDay(),
+                    ProtoSchemaUtil.getEpochDay(
+                            (com.google.type.Date)(ProtoSchemaUtil.convertBuildInValue("google.type.Date",
+                                    (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "dateValue"))))
+            );
+        }
+
+        // TODO Somehow it becomes null when it is 00:00:00.
+        /*
+        if(ProtoSchemaUtil.hasField(message,"timeValue")) {
+            Assert.assertEquals(
+                    LocalTime.of(0,0,0).toSecondOfDay(),
+                    ProtoSchemaUtil.getSecondOfDay((com.google.type.TimeOfDay)(ProtoSchemaUtil.convertBuildInValue("google.type.TimeOfDay",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "timeValue")))));
+        }
+        */
+        if(ProtoSchemaUtil.hasField(message,"datetimeValue")) {
+            Assert.assertEquals(
+                    -62135596800000L,
+                    ProtoSchemaUtil.getEpochMillis((com.google.type.DateTime)(ProtoSchemaUtil.convertBuildInValue("google.type.DateTime",
+                            (DynamicMessage) ProtoSchemaUtil.getFieldValue(message, "datetimeValue")))));
+        }
+
+        Assert.assertEquals(
+                false,
+                ProtoSchemaUtil.getValue(message, "wrappedBoolValue", printer));
+        Assert.assertEquals(
+                "",
+                ProtoSchemaUtil.getValue(message, "wrappedStringValue", printer));
+        Assert.assertEquals(
+                "",
+                new String((byte[]) ProtoSchemaUtil.getValue(message, "wrappedBytesValue", printer), StandardCharsets.UTF_8));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedInt64Value", printer));
+        Assert.assertEquals(
+                0F,
+                ProtoSchemaUtil.getValue(message, "wrappedFloatValue", printer));
+        Assert.assertEquals(
+                0D,
+                ProtoSchemaUtil.getValue(message, "wrappedDoubleValue", printer));
+        Assert.assertEquals(
+                0,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt32Value", printer));
+        Assert.assertEquals(
+                0L,
+                ProtoSchemaUtil.getValue(message, "wrappedUInt64Value", printer));
+
+        // Enum
+        if(ProtoSchemaUtil.hasField(message, "enumValue")) {
+            Assert.assertEquals(
+                    0,
+                    ((Descriptors.EnumValueDescriptor) ProtoSchemaUtil.getFieldValue(message, "enumValue")).getIndex());
+        }
+
+        // OneOf
+        if(ProtoSchemaUtil.hasField(message, "entityName")) {
+            Assert.assertEquals("", ProtoSchemaUtil.getValue(message, "entityName", printer));
+        } else if(ProtoSchemaUtil.hasField(message, "entityAge")) {
+            Assert.assertEquals(0, ProtoSchemaUtil.getValue(message, "entityAge", printer));
+        }
+
+        // Repeated
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "boolValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "stringValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "intValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "longValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "floatValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "doubleValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "uintValues", printer));
+        Assert.assertEquals(new ArrayList<>(), ProtoSchemaUtil.getValue(message, "ulongValues", printer));
+    }
+
+}


### PR DESCRIPTION
Support protobuf format in PubSub sink.
(To use protobuf format, Specify the GCS path of the descriptor file and the full name of the target message).
In addition, PubSub Source module also supports the protobuf format.