### PR TITLE
Update bigquery sink streaming insert

### DIFF
--- a/docs/config/module/sink/bigquery.md
+++ b/docs/config/module/sink/bigquery.md
@@ -18,7 +18,7 @@ Sink module to write the input data to a specified BigQuery table.
 | table | required | String | Specify the Table to be written in BigQuery. {project}:{dataset}. {table} format |
 | writeDisposition | optional | String | One of `WRITE_TRUNCATE`, `WRITE_APPEND`, or `WRITE_EMPTY`. The default is `WRITE_EMPTY` |
 | createDisposition | optional | String | One of `CREATE_IF_NEEDED` and `CREATE_NEVER`. The default is `CREATE_NEVER`.|
-| method | optional | String | One of `FILE_LOADS` and `STREAMING_INSERTS`. If it is not specified, it is determined automatically.|
+| method | optional | String | One of `FILE_LOADS`, `STREAMING_INSERTS` and `STORAGE_WRITE_API`. If it is not specified, it is determined automatically.|
 | dynamicDestination | optional | String | Specify if you want to save each record to a different table. Specify a field name with the table name as a value. |
 | partitioning | optional | String | Specifies that you want to save the data in the partition table when the destination table is generated automatically. One of `DAY` or `HOUR` is specified. The default is disabled.|
 | partitioningField | optional | String | Specify the field name you want to specify as the destination partition when saving to Partition Table. |
@@ -27,8 +27,12 @@ Sink module to write the input data to a specified BigQuery table.
 | ignoreUnknownValues | optional | Boolean | Accept rows that contain values that do not match the schema. Default is false. |
 | ignoreInsertIds | optional | Boolean | Setting this option to true disables insertId based data [deduplication offered by BigQuery](https://cloud.google.com/bigquery/streaming-data-into-bigquery#disabling_best_effort_de-duplication). Default is false. (this option only for streaming mode) |
 | withExtendedErrorInfo | optional | Boolean | Enables extended error information. Default is false. (this option only for streaming mode) |
-| failedInsertRetryPolicy | optional | Enum | Specfies a policy for handling failed inserts. You can specify one of the values `always`,`never`, or `retryTransientErrors`. Default is `retryTransientErrors` which indicates that retry all failures except for known persistent errors. (this option only for streaming mode) |
+| failedInsertRetryPolicy | optional | Enum | Specfies a policy for handling failed inserts. You can specify one of the values `always`,`never`, or `retryTransientErrors`. Default is `always` (this option only for streaming mode) |
 | kmsKey | optional | String | kmsKey |
+| schemaUpdateOptions | optional | Array<String\> | Allows the schema of the destination table to be updated as a side effect of the write. Current support `ALLOW_FIELD_ADDITION` and `ALLOW_FIELD_RELAXATION`. Only applicable when method is `FILE_LOADS` in batch mode. |
+| optimizedWrites | optional | Boolean | If true, enables new codepaths that are expected to use less resources while writing to BigQuery. Not enabled by default in order to maintain backwards compatibility. |
+| autoSharding | optional | Boolean | If true, enables using a dynamically determined number of shards to write to BigQuery. This can be used for both `FILE_LOADS` and `STREAMING_INSERTS`. Only applicable to streaming mode. The default is false. |
+| triggeringFrequencySecond | optional | Integer | Specify the frequency second at which file writes are triggered. This is only applicable when the write method is `FILE_LOADS`, and only streaming mode. |
 
 ## Related example config files
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.28.0</beam.version>
+    <beam.version>2.29.0</beam.version>
 
     <joda.version>2.10.3</joda.version>
     <freemarker.version>2.3.30</freemarker.version>

--- a/src/main/java/com/mercari/solution/util/converter/RecordToTableRowConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/RecordToTableRowConverter.java
@@ -11,6 +11,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -24,6 +26,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class RecordToTableRowConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RecordToTableRowConverter.class);
 
     public static TableSchema convertSchema(final Schema schema) {
         final List<TableFieldSchema> tableFieldSchemas = new ArrayList<>();


### PR DESCRIPTION
* BigQuery sink module
  * support write method `STORAGE_WRITE_API` (but it is not stable)
  * support option `autoSharding` (only streaming mode)
  * support option `schemaUpdateOptions` (only batch mode and only WRITE_APPEND mode)
  * support option `optimizedWrites` (only streaming mode)
  * support option `triggeringFrequencySecond` (only streaming mode)
  * change default to `always` for option `failedInsertRetryPolicy` because of the high risk of delay in problem detection.
* PubSub source module
  * Change avro deserializer module from build-in class to custom because build-in module does not provide logicalType.  