### PR TITLE
Update README.md: remove unnecessary whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ If you want to run in streaming mode, specify streaming=true in the argument as 
 ```sh
 docker run \
   -v ~/.config/gcloud:/mnt/gcloud:ro \
-  -v /{your_work_dir}:/mnt/config:ro \  
+  -v /{your_work_dir}:/mnt/config:ro \
   --rm {region}-docker.pkg.dev/{deploy_project}/{template_repo_name}/local \
   --project={project} \
   --config=/mnt/config/{my_config}.json


### PR DESCRIPTION
Hi, I removed unnecessary whitespaces.
With these whitespaces, the command wasn't working in my environment (zsh).
I got a error below when I ran the command
```
docker: invalid reference format.
See 'docker run --help'.
zsh: command not found: --rm
```

So I suggest a quick fix here 😄 

> Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

↑ Confirmed