### PR TITLE
Fix potential null pointer accesses in teardown() methods

### DIFF
--- a/src/main/java/com/mercari/solution/module/sink/SpannerSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/SpannerSink.java
@@ -957,7 +957,9 @@ public class SpannerSink implements SinkModule {
 
             @Teardown
             public void teardown() {
-                this.spanner.close();
+                if(this.spanner != null) {
+                    this.spanner.close();
+                }
             }
 
             private List<String> createDDLs(org.apache.avro.Schema schema) {
@@ -1876,7 +1878,9 @@ public class SpannerSink implements SinkModule {
 
         @Teardown
         public void teardown() {
-            this.spanner.close();
+            if(this.spanner != null) {
+                this.spanner.close();
+            }
         }
     }
 
@@ -1931,7 +1935,9 @@ public class SpannerSink implements SinkModule {
         @Teardown
         public void teardown() {
             LOG.info("SpannerSink: " + name + " teardown");
-            this.spanner.close();
+            if(this.spanner != null) {
+                this.spanner.close();
+            }
         }
 
     }

--- a/src/main/java/com/mercari/solution/module/sink/fileio/H2Sink.java
+++ b/src/main/java/com/mercari/solution/module/sink/fileio/H2Sink.java
@@ -162,10 +162,12 @@ public class H2Sink implements FileIO.Sink<UnionValue> {
     }
 
     private void teardown() {
-        try {
-            this.connection.close();
-        } catch (SQLException e) {
-            throw new IllegalStateException("Failed to close connection", e);
+        if(this.connection != null) {
+            try {
+                this.connection.close();
+            } catch (SQLException e) {
+                throw new IllegalStateException("Failed to close connection", e);
+            }
         }
     }
 

--- a/src/main/java/com/mercari/solution/module/source/JdbcSource.java
+++ b/src/main/java/com/mercari/solution/module/source/JdbcSource.java
@@ -421,7 +421,9 @@ public class JdbcSource implements SourceModule {
 
             @Teardown
             public void teardown() throws SQLException {
-                this.connection.close();
+                if(this.connection != null) {
+                    this.connection.close();
+                }
             }
 
             @ProcessElement
@@ -642,7 +644,9 @@ public class JdbcSource implements SourceModule {
             }
 
             protected void teardown() throws SQLException {
-                this.connection.close();
+                if(this.connection != null) {
+                    this.connection.close();
+                }
             }
 
             protected void process(

--- a/src/main/java/com/mercari/solution/module/source/SpannerSource.java
+++ b/src/main/java/com/mercari/solution/module/source/SpannerSource.java
@@ -865,7 +865,9 @@ public class SpannerSource implements SourceModule {
 
             @Teardown
             public void teardown() {
-                this.spanner.close();
+                if(this.spanner != null) {
+                    this.spanner.close();
+                }
                 LOG.info("ReadStructSpannerDoFn.teardown");
             }
 

--- a/src/main/java/com/mercari/solution/module/source/WebSocketSource.java
+++ b/src/main/java/com/mercari/solution/module/source/WebSocketSource.java
@@ -587,9 +587,11 @@ public class WebSocketSource implements SourceModule {
             @Teardown
             public void teardown() throws InterruptedException, ExecutionException {
                 LOG.info("WebSocket[" + name + "] teardown");
-                final CompletableFuture<java.net.http.WebSocket> comp = socket.sendClose(java.net.http.WebSocket.NORMAL_CLOSURE, "");
-                this.socket = comp.get();
-            }
+                if(this.socket != null) {
+                    final CompletableFuture<java.net.http.WebSocket> comp = this.socket.sendClose(java.net.http.WebSocket.NORMAL_CLOSURE, "");
+                    this.socket = comp.get();
+                }
+           }
 
             @ProcessElement
             public void processElement(final ProcessContext c,


### PR DESCRIPTION
Hi, I encountered some errors, including a NullPointerException in the stack trace, as shown below. This PR adds null pointer checks to the teardown() methods to prevent these NPEs.

```
Error message from worker: org.apache.beam.sdk.util.UserCodeException: com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
	org.apache.beam.sdk.util.UserCodeException.wrap(UserCodeException.java:39)
	com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadRangeDoFn$DoFnInvoker.invokeSetup(Unknown Source)
	org.apache.beam.sdk.transforms.reflect.DoFnInvokers.tryInvokeSetupFor(DoFnInvokers.java:53)
	org.apache.beam.fn.harness.FnApiDoFnRunner.<init>(FnApiDoFnRunner.java:498)
	org.apache.beam.fn.harness.FnApiDoFnRunner$Factory.createRunnerForPTransform(FnApiDoFnRunner.java:193)
	org.apache.beam.fn.harness.FnApiDoFnRunner$Factory.createRunnerForPTransform(FnApiDoFnRunner.java:161)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:307)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:261)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:261)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:261)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createBundleProcessor(ProcessBundleHandler.java:861)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.lambda$processBundle$0(ProcessBundleHandler.java:511)
	org.apache.beam.fn.harness.control.ProcessBundleHandler$BundleProcessorCache.get(ProcessBundleHandler.java:972)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.processBundle(ProcessBundleHandler.java:507)
	org.apache.beam.fn.harness.control.BeamFnControlClient.delegateOnInstructionRequestType(BeamFnControlClient.java:150)
	org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(BeamFnControlClient.java:115)
	java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)
	java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	java.base/java.lang.Thread.run(Thread.java:840)
	Suppressed: org.apache.beam.sdk.util.UserCodeException: java.lang.NullPointerException: Cannot invoke "java.sql.Connection.close()" because "this.connection" is null
		at org.apache.beam.sdk.util.UserCodeException.wrap(UserCodeException.java:39)
		at com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadRangeDoFn$DoFnInvoker.invokeTeardown(Unknown Source)
		at org.apache.beam.sdk.transforms.reflect.DoFnInvokers.tryInvokeSetupFor(DoFnInvokers.java:56)
		... 19 more
	Caused by: java.lang.NullPointerException: Cannot invoke "java.sql.Connection.close()" because "this.connection" is null
		at com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadDoFn.teardown(JdbcSource.java:645)
		at com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadRangeDoFn.teardown(JdbcSource.java:842)
Caused by: com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
	com.mysql.cj.jdbc.exceptions.SQLError.createCommunicationsException(SQLError.java:165)
	com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:55)
	com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:861)
	com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:449)
	com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:234)
	com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:180)
	org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52)
	org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:374)
	org.apache.commons.pool2.impl.GenericObjectPool.create(GenericObjectPool.java:571)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:298)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:223)
	org.apache.commons.dbcp2.PoolingDataSource.getConnection(PoolingDataSource.java:141)
	org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:731)
	org.apache.commons.dbcp2.DataSourceConnectionFactory.createConnection(DataSourceConnectionFactory.java:83)
	org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:374)
	org.apache.commons.pool2.impl.GenericObjectPool.create(GenericObjectPool.java:571)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:298)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:223)
	org.apache.commons.dbcp2.PoolingDataSource.getConnection(PoolingDataSource.java:141)
	com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadDoFn.setup(JdbcSource.java:614)
	com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadRangeDoFn.setup(JdbcSource.java:837)
Caused by: com.mysql.cj.exceptions.CJCommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
	java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:52)
	com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:95)
	com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:140)
	com.mysql.cj.exceptions.ExceptionFactory.createCommunicationsException(ExceptionFactory.java:156)
	com.mysql.cj.protocol.a.NativeSocketConnection.connect(NativeSocketConnection.java:79)
	com.mysql.cj.NativeSession.connect(NativeSession.java:139)
	com.mysql.cj.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:980)
	com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:851)
	com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:449)
	com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:234)
	com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:180)
	org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52)
	org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:374)
	org.apache.commons.pool2.impl.GenericObjectPool.create(GenericObjectPool.java:571)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:298)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:223)
	org.apache.commons.dbcp2.PoolingDataSource.getConnection(PoolingDataSource.java:141)
	org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:731)
	org.apache.commons.dbcp2.DataSourceConnectionFactory.createConnection(DataSourceConnectionFactory.java:83)
	org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:374)
	org.apache.commons.pool2.impl.GenericObjectPool.create(GenericObjectPool.java:571)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:298)
	org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:223)
	org.apache.commons.dbcp2.PoolingDataSource.getConnection(PoolingDataSource.java:141)
	com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadDoFn.setup(JdbcSource.java:614)
	com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadRangeDoFn.setup(JdbcSource.java:837)
	com.mercari.solution.module.source.JdbcSource$JdbcBatchTableSource$TableReadRangeDoFn$DoFnInvoker.invokeSetup(Unknown Source)
	org.apache.beam.sdk.transforms.reflect.DoFnInvokers.tryInvokeSetupFor(DoFnInvokers.java:53)
	org.apache.beam.fn.harness.FnApiDoFnRunner.<init>(FnApiDoFnRunner.java:498)
	org.apache.beam.fn.harness.FnApiDoFnRunner$Factory.createRunnerForPTransform(FnApiDoFnRunner.java:193)
	org.apache.beam.fn.harness.FnApiDoFnRunner$Factory.createRunnerForPTransform(FnApiDoFnRunner.java:161)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:307)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:261)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:261)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createRunnerAndConsumersForPTransformRecursively(ProcessBundleHandler.java:261)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.createBundleProcessor(ProcessBundleHandler.java:861)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.lambda$processBundle$0(ProcessBundleHandler.java:511)
	org.apache.beam.fn.harness.control.ProcessBundleHandler$BundleProcessorCache.get(ProcessBundleHandler.java:972)
	org.apache.beam.fn.harness.control.ProcessBundleHandler.processBundle(ProcessBundleHandler.java:507)
	org.apache.beam.fn.harness.control.BeamFnControlClient.delegateOnInstructionRequestType(BeamFnControlClient.java:150)
	org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(BeamFnControlClient.java:115)
	java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)
	java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.net.ConnectException: Connection timed out
	java.base/sun.nio.ch.Net.connect0(Native Method)
	java.base/sun.nio.ch.Net.connect(Net.java:579)
	java.base/sun.nio.ch.Net.connect(Net.java:568)
	java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:593)
	java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	java.base/java.net.Socket.connect(Socket.java:633)
	java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304)
	java.base/sun.security.ssl.BaseSSLSocketImpl.connect(BaseSSLSocketImpl.java:174)
	com.google.cloud.sql.core.Connector.connect(Connector.java:121)
	com.google.cloud.sql.core.InternalConnectorRegistry.connect(InternalConnectorRegistry.java:179)
	com.google.cloud.sql.mysql.SocketFactory.connect(SocketFactory.java:63)
	com.google.cloud.sql.mysql.SocketFactory.connect(SocketFactory.java:45)
	com.mysql.cj.protocol.a.NativeSocketConnection.connect(NativeSocketConnection.java:53)
	... 42 more 
```