### PR TITLE
Fix config argument prefix in README

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -149,7 +149,7 @@ The notation follows the FreeMarker specification.
 }
 ```
 
-You can assign variables to the Config file at runtime by prefixing it with the parameter `template.`.
+You can assign variables to the Config file at runtime by prefixing it with the parameter `args.`.
 
 ```sh
 gcloud dataflow flex-template run {job_name} \


### PR DESCRIPTION
Hi, I noticed a small issue in the [config README](https://github.com/mercari/pipeline/compare/docs/config/README.md): it still references the legacy parameter prefix `template.`.