### PR TITLE
Add UUID field type and select casting support

### DIFF
--- a/src/main/java/com/mercari/solution/module/MElement.java
+++ b/src/main/java/com/mercari/solution/module/MElement.java
@@ -364,7 +364,7 @@ public class MElement implements Serializable {
                 case Number n -> n.doubleValue() > 0;
                 default -> throw new IllegalArgumentException();
             };
-            case string, json -> switch (primitiveValue) {
+            case string, uuid, json -> switch (primitiveValue) {
                 case String s -> s;
                 case ByteBuffer bb -> new String(Base64.getDecoder().decode(bb.array()), StandardCharsets.UTF_8);
                 case byte[] b -> new String(b, StandardCharsets.UTF_8);

--- a/src/main/java/com/mercari/solution/module/Schema.java
+++ b/src/main/java/com/mercari/solution/module/Schema.java
@@ -523,6 +523,7 @@ public class Schema implements Serializable {
 
         public static FieldType BOOLEAN = FieldType.type(Type.bool);
         public static FieldType STRING = FieldType.type(Type.string);
+        public static FieldType UUID = FieldType.type(Type.uuid);
         public static FieldType JSON = FieldType.type(Type.json);
         public static FieldType BYTES = FieldType.type(Type.bytes);
         public static FieldType INT32 = FieldType.type(Type.int32);
@@ -1148,6 +1149,7 @@ public class Schema implements Serializable {
     public enum Type {
         bool,
         string,
+        uuid,
         json,
         bytes,
         int8,
@@ -1178,6 +1180,7 @@ public class Schema implements Serializable {
                 case "bool", "boolean" -> Type.bool;
                 case "bytes", "blob" -> Type.bytes;
                 case "string", "char" -> Type.string;
+                case "uuid" -> Type.uuid;
                 case "json" -> Type.json;
                 case "byte", "int8" -> Type.int8;
                 case "short", "int16" -> Type.int16;
@@ -1208,6 +1211,7 @@ public class Schema implements Serializable {
                 case "float", "float32" -> value.getAsFloat();
                 case "double", "float64" -> value.getAsDouble();
                 case "string", "json" -> value.getAsString();
+                case "uuid" -> UUID.fromString(value.getAsString()).toString();
                 case "date" -> Long.valueOf(DateTimeUtil.toLocalDate(value.getAsString()).toEpochDay()).intValue();
                 case "time" -> DateTimeUtil.toLocalTime(value.getAsString()).toNanoOfDay() / 1000L;
                 case "timestamp" -> DateTimeUtil.toJodaInstant(value.getAsString()).getMillis() * 1000L;

--- a/src/main/java/com/mercari/solution/module/sink/AuxiaSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/AuxiaSink.java
@@ -49,7 +49,7 @@ public class AuxiaSink extends Sink {
                         errorMessages.add("field: " + field + " does not exist in input schema: " + inputSchema);
                     } else {
                         switch (inputSchema.getField(field).getFieldType().getType()) {
-                            case string, json, bytes -> {}
+                            case string, uuid, json, bytes -> {}
                             default -> errorMessages.add("field: " + field + " type must be json, string or bytes : " + inputSchema);
                         }
                     }

--- a/src/main/java/com/mercari/solution/module/sink/FilesSink.java
+++ b/src/main/java/com/mercari/solution/module/sink/FilesSink.java
@@ -93,7 +93,7 @@ public class FilesSink extends Sink {
                     format = switch (inputField.getFieldType().getType()) {
                         case json, element, array, map -> Format.json;
                         case bytes -> Format.bytes;
-                        case string -> Format.text;
+                        case string, uuid -> Format.text;
                         default -> Format.text;
                     };
                 } else {
@@ -244,7 +244,7 @@ public class FilesSink extends Sink {
                     case json -> {
                         final Schema.Field field = ElementSchemaUtil.getInputField(content.field, inputSchema.getFields());
                         yield switch (field.getFieldType().getType()) {
-                            case string, json -> fieldValue;
+                            case string, uuid, json -> fieldValue;
                             case map -> MapToJsonConverter.convertObject((Map) fieldValue).toString();
                             case element -> ElementToJsonConverter.convert(field.getFieldType().getElementSchema(), (Map) fieldValue);
                             case null -> null;

--- a/src/main/java/com/mercari/solution/module/source/CreateSource.java
+++ b/src/main/java/com/mercari/solution/module/source/CreateSource.java
@@ -583,6 +583,7 @@ public class CreateSource extends Source {
         final String elementValue = elements.get(sequence.intValue());
         return switch (elementFieldType.getType()) {
             case string -> elementValue;
+            case uuid -> UUID.fromString(elementValue).toString();
             case bytes -> ByteBuffer.wrap(Base64.getDecoder().decode(elementValue));
             case date -> Long.valueOf(DateTimeUtil.toLocalDate(elementValue.replaceAll("\"", "")).toEpochDay()).intValue();
             case time -> DateTimeUtil.toLocalTime(elementValue.replaceAll("\"", "")).toNanoOfDay() / 1000L;

--- a/src/main/java/com/mercari/solution/util/cloud/crm/AuxiaUtil.java
+++ b/src/main/java/com/mercari/solution/util/cloud/crm/AuxiaUtil.java
@@ -540,7 +540,7 @@ public class AuxiaUtil {
             final DynamicMessage.Builder builder = DynamicMessage.newBuilder(propertyValueMessage);
             switch (fieldType.getType()) {
                 case bool -> builder.setField(propertyValueBooleanField, value);
-                case string, json -> builder.setField(propertyValueStringField, value);
+                case string, uuid, json -> builder.setField(propertyValueStringField, value);
                 case float32 -> builder.setField(propertyValueDoubleField, ((Float)value).doubleValue());
                 case float64 -> builder.setField(propertyValueDoubleField, value);
                 case int32 -> builder.setField(propertyValueLongField, ((Integer) value).longValue());

--- a/src/main/java/com/mercari/solution/util/domain/db/stmt/PreparedStatementTemplate.java
+++ b/src/main/java/com/mercari/solution/util/domain/db/stmt/PreparedStatementTemplate.java
@@ -150,8 +150,12 @@ public class PreparedStatementTemplate implements Serializable {
         public void setUUID(int index, String value) throws java.sql.SQLException {
             List<Integer> mappedIndices = placeholderMappings.getMappings().get(index);
             for (Integer placeholderIndex : mappedIndices) {
-                final UUID uuid = UUID.fromString(value);
-                preparedStatement.setObject(placeholderIndex, uuid, Types.OTHER);
+                if(value == null) {
+                    preparedStatement.setNull(placeholderIndex, Types.OTHER, "uuid");
+                } else {
+                    final UUID uuid = UUID.fromString(value);
+                    preparedStatement.setObject(placeholderIndex, uuid, Types.OTHER);
+                }
             }
         }
 
@@ -298,4 +302,3 @@ public class PreparedStatementTemplate implements Serializable {
         }
     }
 }
-

--- a/src/main/java/com/mercari/solution/util/domain/sql/calcite/SelectConverter.java
+++ b/src/main/java/com/mercari/solution/util/domain/sql/calcite/SelectConverter.java
@@ -26,7 +26,7 @@ public class SelectConverter {
                 System.out.println("literal: " + type + " value: " + literal.toValue());
                 switch (type) {
                     case bool -> jsonObject.addProperty("value", literal.booleanValue());
-                    case string -> jsonObject.addProperty("value", literal.toValue());
+                    case string, uuid -> jsonObject.addProperty("value", literal.toValue());
                     case int8, int16, int32 -> jsonObject.addProperty("value", literal.intValue(true));
                     case int64 -> jsonObject.addProperty("value", literal.longValue(true));
                     case decimal -> jsonObject.addProperty("value", literal.bigDecimalValue());

--- a/src/main/java/com/mercari/solution/util/pipeline/select/Bytes.java
+++ b/src/main/java/com/mercari/solution/util/pipeline/select/Bytes.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class Bytes implements SelectFunction {
 
@@ -109,6 +110,7 @@ public class Bytes implements SelectFunction {
         return switch (type) {
             case bool -> org.apache.hadoop.hbase.util.Bytes.toBoolean(bytes);
             case string, json -> org.apache.hadoop.hbase.util.Bytes.toString(bytes);
+            case uuid -> UUID.fromString(org.apache.hadoop.hbase.util.Bytes.toString(bytes)).toString();
             case int16 -> org.apache.hadoop.hbase.util.Bytes.toShort(bytes);
             case int32, date -> org.apache.hadoop.hbase.util.Bytes.toInt(bytes);
             case int64, time, timestamp -> org.apache.hadoop.hbase.util.Bytes.toLong(bytes);

--- a/src/main/java/com/mercari/solution/util/pipeline/select/Cast.java
+++ b/src/main/java/com/mercari/solution/util/pipeline/select/Cast.java
@@ -6,9 +6,11 @@ import com.mercari.solution.module.Schema;
 import com.mercari.solution.util.schema.ElementSchemaUtil;
 import org.joda.time.Instant;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class Cast implements SelectFunction {
 
@@ -81,7 +83,39 @@ public class Cast implements SelectFunction {
     @Override
     public Object apply(Map<String, Object> input, Instant timestamp) {
         final Object value = ElementSchemaUtil.getValue(input, field);
+        final Schema.Type inputType = inputFields.getFirst().getFieldType().getType();
+        if(Schema.Type.uuid.equals(outputFieldType.getType()) && Schema.Type.bytes.equals(inputType)) {
+            return bytesToUuid(value);
+        } else if(Schema.Type.bytes.equals(outputFieldType.getType()) && Schema.Type.uuid.equals(inputType)) {
+            return uuidToBytes(value);
+        }
         return ElementSchemaUtil.getAsPrimitive(outputFieldType, value);
+    }
+
+    private static String bytesToUuid(final Object value) {
+        if(value == null) {
+            return null;
+        }
+        final ByteBuffer buffer = switch (value) {
+            case ByteBuffer b -> b.duplicate();
+            case byte[] b -> ByteBuffer.wrap(b);
+            default -> throw new IllegalArgumentException("UUID bytes value must be byte[] or ByteBuffer");
+        };
+        if(buffer.remaining() != 16) {
+            throw new IllegalArgumentException("UUID bytes value must be exactly 16 bytes");
+        }
+        return new UUID(buffer.getLong(), buffer.getLong()).toString();
+    }
+
+    private static ByteBuffer uuidToBytes(final Object value) {
+        if(value == null) {
+            return null;
+        }
+        final UUID uuid = UUID.fromString(value.toString());
+        return ByteBuffer.allocate(16)
+                .putLong(uuid.getMostSignificantBits())
+                .putLong(uuid.getLeastSignificantBits())
+                .flip();
     }
 
 }

--- a/src/main/java/com/mercari/solution/util/pipeline/select/Scrape.java
+++ b/src/main/java/com/mercari/solution/util/pipeline/select/Scrape.java
@@ -286,6 +286,7 @@ public class Scrape implements SelectFunction {
 
         final Object output = switch (scrape.outputFieldType.getType()) {
             case string -> scrape.trim ? text.trim() : text;
+            case uuid -> UUID.fromString(text.trim()).toString();
             case bool -> Boolean.parseBoolean(text.trim());
             case int32 -> Integer.parseInt(text.trim().replaceAll(",", ""));
             case int64 -> Long.parseLong(text.trim().replaceAll(",", ""));

--- a/src/main/java/com/mercari/solution/util/schema/AvroSchemaUtil.java
+++ b/src/main/java/com/mercari/solution/util/schema/AvroSchemaUtil.java
@@ -1908,7 +1908,7 @@ public class AvroSchemaUtil {
 
     private static Object read(BinaryDecoder decoder, com.mercari.solution.module.Schema.FieldType fieldType) throws IOException {
         return switch (fieldType.getType()) {
-            case string, json -> decoder.readString();
+            case string, uuid, json -> decoder.readString();
             case bool -> decoder.readBoolean();
             case bytes, decimal -> decoder.readBytes(null);
             case int32, date, enumeration -> decoder.readInt();

--- a/src/main/java/com/mercari/solution/util/schema/BigtableSchemaUtil.java
+++ b/src/main/java/com/mercari/solution/util/schema/BigtableSchemaUtil.java
@@ -1040,7 +1040,7 @@ public class BigtableSchemaUtil {
             return null;
         }
         return switch (dynamicType) {
-            case string, json -> primitiveValue.toString();
+            case string, uuid, json -> primitiveValue.toString();
             case bool -> switch (primitiveValue) {
                 case String s -> Boolean.parseBoolean(s);
                 case Utf8 u -> Boolean.parseBoolean(u.toString());
@@ -1126,7 +1126,7 @@ public class BigtableSchemaUtil {
         final byte[] bytes = byteString.toByteArray();
         return switch (fieldtype.getType()) {
             case bool -> Bytes.toBoolean(bytes);
-            case string, json -> Bytes.toString(bytes);
+            case string, uuid, json -> Bytes.toString(bytes);
             case bytes -> ByteBuffer.wrap(bytes);
             case int16 -> Bytes.toShort(bytes);
             case int32, date, enumeration -> Bytes.toInt(bytes);
@@ -1212,7 +1212,7 @@ public class BigtableSchemaUtil {
             case int64, time, timestamp -> new VLongWritable();
             case float32 -> new FloatWritable();
             case float64 -> new DoubleWritable();
-            case string, json -> new Text();
+            case string, uuid, json -> new Text();
             case bytes -> new BytesWritable();
             case map, element -> new MapWritable();
             case array -> {
@@ -1229,7 +1229,7 @@ public class BigtableSchemaUtil {
         }
         return switch (fieldType.getType()) {
             case bool -> BooleanWritable.class;
-            case string, json -> Text.class;
+            case string, uuid, json -> Text.class;
             case bytes -> BytesWritable.class;
             case int16 -> ShortWritable.class;
             case int32, date, enumeration -> VIntWritable.class;
@@ -1238,7 +1238,7 @@ public class BigtableSchemaUtil {
             case float64 -> DoubleWritable.class;
             case array -> switch (fieldType.getArrayValueType().getType()) {
                 case bool -> BoolArrayWritable.class;
-                case string, json -> TextArrayWritable.class;
+                case string, uuid, json -> TextArrayWritable.class;
                 case bytes -> BytesArrayWritable.class;
                 case int16 -> ShortArrayWritable.class;
                 case int32, date, enumeration -> IntArrayWritable.class;

--- a/src/main/java/com/mercari/solution/util/schema/CalciteSchemaUtil.java
+++ b/src/main/java/com/mercari/solution/util/schema/CalciteSchemaUtil.java
@@ -79,7 +79,7 @@ public class CalciteSchemaUtil {
             return null;
         }
         return switch (fieldType.getType()) {
-            case bool, string, json, int32, int64, float32, float64 -> primitiveValue;
+            case bool, string, uuid, json, int32, int64, float32, float64 -> primitiveValue;
             case date -> Date.valueOf(LocalDate.ofEpochDay((Integer)primitiveValue));
             case time -> Time.valueOf(LocalTime.ofNanoOfDay((Long) primitiveValue * 1000L));
             case timestamp -> Timestamp.valueOf(DateTimeUtil.toLocalDateTime((Long) primitiveValue));
@@ -209,7 +209,7 @@ public class CalciteSchemaUtil {
     private static SqlTypeName convertSqlTypeName(final Schema.FieldType fieldType) {
         return switch (fieldType.getType()) {
             case bool -> SqlTypeName.BOOLEAN;
-            case string, json, enumeration -> SqlTypeName.VARCHAR;
+            case string, uuid, json, enumeration -> SqlTypeName.VARCHAR;
             case bytes -> SqlTypeName.BINARY;
             case int16, int8 -> SqlTypeName.SMALLINT;
             case int32 -> SqlTypeName.INTEGER;
@@ -342,7 +342,7 @@ public class CalciteSchemaUtil {
             final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
             final RelDataType relDataType = switch (this.fieldType.getType()) {
                 case bool -> typeFactory.createSqlType(SqlTypeName.BOOLEAN);
-                case string, json -> typeFactory.createSqlType(SqlTypeName.VARCHAR);
+                case string, uuid, json -> typeFactory.createSqlType(SqlTypeName.VARCHAR);
                 case bytes ->  typeFactory.createSqlType(SqlTypeName.BINARY);
                 case int32 -> typeFactory.createSqlType(SqlTypeName.INTEGER);
                 case int64 -> typeFactory.createSqlType(SqlTypeName.BIGINT);

--- a/src/main/java/com/mercari/solution/util/schema/ElementSchemaUtil.java
+++ b/src/main/java/com/mercari/solution/util/schema/ElementSchemaUtil.java
@@ -194,6 +194,7 @@ public class ElementSchemaUtil {
                 case ByteBuffer bb -> new String(bb.array(), StandardCharsets.UTF_8);
                 case Object o -> o.toString();
             };
+            case uuid -> java.util.UUID.fromString(primitiveValue.toString()).toString();
             case bytes -> switch (primitiveValue) {
                 case ByteBuffer bb -> bb;
                 case byte[] b -> ByteBuffer.wrap(b);

--- a/src/main/java/com/mercari/solution/util/schema/converter/AvroToElementConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/AvroToElementConverter.java
@@ -27,7 +27,9 @@ public class AvroToElementConverter {
         final Schema.FieldType fieldType = switch (avroFieldSchema.getType()) {
             case BOOLEAN -> Schema.FieldType.BOOLEAN;
             case STRING -> {
-                if(AvroSchemaUtil.isSqlTypeJson(avroFieldSchema)) {
+                if(LogicalTypes.uuid().equals(avroFieldSchema.getLogicalType())) {
+                    yield Schema.FieldType.UUID;
+                } else if(AvroSchemaUtil.isSqlTypeJson(avroFieldSchema)) {
                     yield Schema.FieldType.JSON;
                 } else {
                     yield Schema.FieldType.STRING;

--- a/src/main/java/com/mercari/solution/util/schema/converter/BigtableRowToElementConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/BigtableRowToElementConverter.java
@@ -31,7 +31,7 @@ public class BigtableRowToElementConverter {
         final Schema.Field keyField = schema.getField(KEY_FIELD_NAME);
         if(keyField != null) {
             switch (keyField.getFieldType().getType()) {
-                case string -> values.put(KEY_FIELD_NAME, row.getKey().toStringUtf8());
+                case string, uuid -> values.put(KEY_FIELD_NAME, row.getKey().toStringUtf8());
                 case bytes -> values.put(KEY_FIELD_NAME, ByteBuffer.wrap(row.getKey().toByteArray()));
             }
         }

--- a/src/main/java/com/mercari/solution/util/schema/converter/CsvToElementConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/CsvToElementConverter.java
@@ -14,6 +14,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class CsvToElementConverter {
 
@@ -49,6 +50,7 @@ public class CsvToElementConverter {
             return switch (fieldType.getType()) {
                 case bool -> Boolean.valueOf(str.trim());
                 case string, json, enumeration -> str;
+                case uuid -> UUID.fromString(str).toString();
                 case bytes -> ByteBuffer.wrap(Base64.getDecoder().decode(str));
                 case int32 -> Integer.parseInt(str);
                 case int64 -> Long.parseLong(str);

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToAvroConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToAvroConverter.java
@@ -122,6 +122,7 @@ public class ElementToAvroConverter {
         final org.apache.avro.Schema fieldSchema = switch (fieldType.getType()) {
             case bool -> org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN);
             case string -> org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING);
+            case uuid -> LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
             case bytes -> org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES);
             case decimal -> LogicalTypes.decimal(38, 9).addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES));
             case int8, int16, int32 -> org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT);

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToDocumentConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToDocumentConverter.java
@@ -55,7 +55,7 @@ public class ElementToDocumentConverter {
         }
         return switch (fieldType.getType()) {
             case bool -> getValue(fieldType, Boolean.valueOf(strValue));
-            case string -> getValue(fieldType, strValue);
+            case string, uuid -> getValue(fieldType, strValue);
             case bytes -> getValue(fieldType, Base64.getDecoder().decode(strValue));
             case int16 -> getValue(fieldType, Short.valueOf(strValue));
             case int32 -> getValue(fieldType, Integer.valueOf(strValue));
@@ -77,7 +77,7 @@ public class ElementToDocumentConverter {
         }
         return switch (fieldType.getType()) {
             case bool -> Value.newBuilder().setBooleanValue(((Boolean) v)).build();
-            case string -> Value.newBuilder().setStringValue(((String) v)).build();
+            case string, uuid -> Value.newBuilder().setStringValue(((String) v)).build();
             case bytes -> Value.newBuilder().setBytesValue(ByteString.copyFrom((byte[]) v)).build();
             case int8 -> Value.newBuilder().setIntegerValue(((Byte) v).longValue()).build();
             case int16 -> Value.newBuilder().setIntegerValue(((Short) v).longValue()).build();

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToEntityConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToEntityConverter.java
@@ -83,7 +83,7 @@ public class ElementToEntityConverter {
                     yield Value.newBuilder().setBlobValue(byteString);
                 }
             }
-            case string, enumeration -> {
+            case string, uuid, enumeration -> {
                 final String stringValue = value.toString();
                 if(stringValue.getBytes().length >= DatastoreUtil.QUOTE_VALUE_SIZE) {
                     yield Value.newBuilder().setStringValue(stringValue).setExcludeFromIndexes(true);

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToJsonConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToJsonConverter.java
@@ -116,7 +116,7 @@ public class ElementToJsonConverter {
                                 + " for value: " + primitiveValue + " is not supported");
                     }
                 }
-                case string, json -> obj.addProperty(fieldName, primitiveValue.toString());
+                case string, uuid, json -> obj.addProperty(fieldName, primitiveValue.toString());
                 case bytes -> {
                     final byte[] bytes = switch (primitiveValue) {
                         case ByteBuffer b -> b.array();
@@ -197,7 +197,7 @@ public class ElementToJsonConverter {
                         }
                     })
                     .forEach(array::add);
-            case string, json -> arrayValue.stream()
+            case string, uuid, json -> arrayValue.stream()
                     .filter(Objects::nonNull)
                     .map(Object::toString)
                     .forEach(array::add);
@@ -258,7 +258,7 @@ public class ElementToJsonConverter {
             switch (mapValueType.getType()) {
                 case bool -> mapObject.addProperty(name, (Boolean) entry.getValue());
                 case int8, int16, int32, int64, float8, float16, float32, float64 -> mapObject.addProperty(name, (Number) entry.getValue());
-                case string, json -> mapObject.addProperty(name, entry.getValue().toString());
+                case string, uuid, json -> mapObject.addProperty(name, entry.getValue().toString());
                 case bytes -> mapObject.addProperty(name, java.util.Base64.getEncoder().encodeToString(((ByteBuffer)entry.getValue()).array()));
                 case date -> mapObject.addProperty(name, LocalDate.ofEpochDay((Integer)entry.getValue()).toString());
                 case time -> mapObject.addProperty(name, LocalTime.ofNanoOfDay((Long)entry.getValue() / 1000L).toString());

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToProtoConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToProtoConverter.java
@@ -152,7 +152,7 @@ public class ElementToProtoConverter {
                 default -> throw new IllegalArgumentException();
             };
             case STRING -> switch (fieldType.getType()) {
-                case string -> value;
+                case string, uuid -> value;
                 case int32, int64, float32, float64, date, time -> value.toString();
                 case enumeration -> fieldType.getSymbols().get((Integer) value);
                 default -> throw new IllegalArgumentException();

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToRowConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToRowConverter.java
@@ -73,7 +73,7 @@ public class ElementToRowConverter {
     public static org.apache.beam.sdk.schemas.Schema.FieldType convertFieldType(final Schema.FieldType fieldType) {
         final org.apache.beam.sdk.schemas.Schema.FieldType rowFieldType = switch (fieldType.getType()) {
             case bytes -> org.apache.beam.sdk.schemas.Schema.FieldType.BYTES;
-            case string, json -> org.apache.beam.sdk.schemas.Schema.FieldType.STRING;
+            case string, uuid, json -> org.apache.beam.sdk.schemas.Schema.FieldType.STRING;
             case int8 -> org.apache.beam.sdk.schemas.Schema.FieldType.BYTE;
             case int16 -> org.apache.beam.sdk.schemas.Schema.FieldType.INT16;
             case int32 -> org.apache.beam.sdk.schemas.Schema.FieldType.INT32;

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToSpannerMutationConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToSpannerMutationConverter.java
@@ -93,7 +93,7 @@ public class ElementToSpannerMutationConverter {
             final Object fieldValue = values.get(field.getName());
             switch (field.getFieldType().getType()) {
                 case bool -> keyBuilder = keyBuilder.append((Boolean)fieldValue);
-                case enumeration, string -> keyBuilder = keyBuilder.append(fieldValue == null ? null : fieldValue.toString());
+                case enumeration, string, uuid -> keyBuilder = keyBuilder.append(fieldValue == null ? null : fieldValue.toString());
                 case float32 -> keyBuilder = keyBuilder.append((Float)fieldValue);
                 case float64 -> keyBuilder = keyBuilder.append((Double)fieldValue);
                 case bytes -> {
@@ -131,7 +131,7 @@ public class ElementToSpannerMutationConverter {
                 final Boolean booleanValue = (Boolean) value;
                 builder.set(fieldName).to(booleanValue);
             }
-            case enumeration, string -> {
+            case enumeration, string, uuid -> {
                 final String stringValue = Optional.ofNullable(value).map(Object::toString).orElse(null);
                 builder.set(fieldName).to(stringValue);
             }

--- a/src/main/java/com/mercari/solution/util/schema/converter/ElementToTableRowConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ElementToTableRowConverter.java
@@ -64,7 +64,7 @@ public class ElementToTableRowConverter {
                 case Number n -> n.doubleValue() > 0;
                 default -> throw new IllegalArgumentException();
             };
-            case string, json -> switch (value) {
+            case string, uuid, json -> switch (value) {
                 case String s -> s;
                 default -> value.toString();
             };
@@ -168,7 +168,7 @@ public class ElementToTableRowConverter {
                 .setMode(mode);
         return switch (fieldType.getType()) {
             case bool -> tableFieldSchema.setName(name).setType("BOOLEAN");
-            case string, enumeration -> tableFieldSchema.setName(name).setType("STRING");
+            case string, uuid, enumeration -> tableFieldSchema.setName(name).setType("STRING");
             case geography -> tableFieldSchema.setName(name).setType("GEOGRAPHY");
             case json -> tableFieldSchema.setName(name).setType("JSON");
             case bytes -> tableFieldSchema.setName(name).setType("BYTES");

--- a/src/main/java/com/mercari/solution/util/schema/converter/JsonToElementConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/JsonToElementConverter.java
@@ -66,6 +66,7 @@ public class JsonToElementConverter {
         }
         return switch (fieldType.getType()) {
             case string, json -> jsonElement.isJsonPrimitive() ? jsonElement.getAsString() : jsonElement.toString();
+            case uuid -> UUID.fromString(jsonElement.getAsString()).toString();
             case bytes -> jsonElement.isJsonPrimitive() ? Base64.getDecoder().decode(jsonElement.getAsString()) : null;
             case int8 -> jsonElement.isJsonPrimitive() ? jsonElement.getAsByte() : null;
             case int16 -> jsonElement.isJsonPrimitive() ? jsonElement.getAsShort() : null;

--- a/src/main/java/com/mercari/solution/util/schema/converter/JsonToMapConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/JsonToMapConverter.java
@@ -54,6 +54,7 @@ public class JsonToMapConverter {
                     yield element.toString();
                 }
             }
+            case uuid -> UUID.fromString(element.getAsString()).toString();
             case int32 -> element.getAsInt();
             case int64 -> element.getAsLong();
             case float32 -> element.getAsFloat();

--- a/src/main/java/com/mercari/solution/util/schema/converter/ToStatementConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/ToStatementConverter.java
@@ -73,7 +73,7 @@ public class ToStatementConverter {
                 case ENUM, STRING -> {
                     if(LogicalTypes.uuid().equals(fieldSchema.getLogicalType())) {
                         if (isNull) {
-                            statement.setNull(index, Types.OTHER);
+                            statement.setUUID(index, null);
                         } else {
                             statement.setUUID(index, (record.get(field.name())).toString());
                         }
@@ -219,7 +219,10 @@ public class ToStatementConverter {
                     }
                 }
                 case STRING -> {
-                    if (isNull) {
+                    if(field.getOptions().hasOption("spannerType")
+                            && "UUID".equalsIgnoreCase(field.getOptions().getValue("spannerType"))) {
+                        statement.setUUID(index, isNull ? null : row.getString(field.getName()));
+                    } else if (isNull) {
                         statement.setNull(index, Types.VARCHAR);
                     } else {
                         statement.setString(index, row.getString(field.getName()));
@@ -284,6 +287,11 @@ public class ToStatementConverter {
                     } else {
                         statement.setString(index, struct.getString(field.getName()));
                     }
+                }
+                case UUID -> {
+                    statement.setUUID(index, struct.isNull(field.getName())
+                            ? null
+                            : struct.getUuid(field.getName()).toString());
                 }
                 case BYTES -> {
                     if (struct.isNull(field.getName())) {

--- a/src/main/resources/server/docs/module/transform/select.md
+++ b/src/main/resources/server/docs/module/transform/select.md
@@ -120,6 +120,10 @@ Casts a field value to a different type.
   type: string
 ```
 
+UUID values can be cast to `bytes` using their standard 16-byte representation,
+and 16-byte fields can be cast back to `uuid`. Casting a byte sequence whose
+length is not 16 to `uuid` produces an error.
+
 ### constant
 
 Creates a field with a constant value.
@@ -605,6 +609,7 @@ The following type names can be used in the `type` parameter:
 |-------------------|----------------------------|
 | `bool`, `boolean` | Boolean                    |
 | `string`          | String                     |
+| `uuid`            | UUID                       |
 | `bytes`           | Byte array                 |
 | `int32`, `integer`| 32-bit integer             |
 | `int64`, `long`   | 64-bit integer             |

--- a/src/test/java/com/mercari/solution/util/pipeline/select/SelectFunctionTest.java
+++ b/src/test/java/com/mercari/solution/util/pipeline/select/SelectFunctionTest.java
@@ -4,15 +4,90 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mercari.solution.module.Schema;
+import com.mercari.solution.util.schema.AvroSchemaUtil;
+import com.mercari.solution.util.schema.ElementSchemaUtil;
+import com.mercari.solution.util.schema.converter.AvroToElementConverter;
+import com.mercari.solution.util.schema.converter.ElementToAvroConverter;
+import org.apache.avro.LogicalTypes;
 import org.joda.time.Instant;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class SelectFunctionTest {
+
+    @Test
+    public void testUuidCast() {
+        final String uuid = "10000000-0000-0000-0000-000000000001";
+        final List<Schema.Field> inputFields = List.of(
+                Schema.Field.of("textId", Schema.FieldType.STRING),
+                Schema.Field.of("uuidId", Schema.FieldType.UUID));
+        final JsonArray array = new Gson().fromJson("""
+                [
+                  { "name": "uuidId", "field": "textId", "type": "uuid" },
+                  { "name": "textId", "field": "uuidId", "type": "string" }
+                ]
+                """, JsonArray.class);
+
+        final List<SelectFunction> functions = SelectFunction.of(array, inputFields);
+        final Schema outputSchema = SelectFunction.createSchema(functions);
+        Assert.assertEquals(Schema.Type.uuid, outputSchema.getField("uuidId").getFieldType().getType());
+        Assert.assertEquals(Schema.Type.string, outputSchema.getField("textId").getFieldType().getType());
+
+        final Map<String, Object> values = Map.of("textId", uuid, "uuidId", uuid);
+        final Map<String, Object> results = SelectFunction.apply(functions, values, Instant.EPOCH);
+        Assert.assertEquals(uuid, results.get("uuidId"));
+        Assert.assertEquals(uuid, results.get("textId"));
+
+        final org.apache.avro.Schema avroSchema = ElementToAvroConverter.convertSchema(outputSchema.getFields());
+        Assert.assertEquals(LogicalTypes.uuid(), AvroSchemaUtil.unnestUnion(avroSchema.getField("uuidId").schema()).getLogicalType());
+        Assert.assertNull(AvroSchemaUtil.unnestUnion(avroSchema.getField("textId").schema()).getLogicalType());
+        Assert.assertEquals(Schema.Type.uuid,
+                AvroToElementConverter.convertFields(avroSchema.getFields()).getFirst().getFieldType().getType());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUuidCastRejectsInvalidValue() {
+        ElementSchemaUtil.getAsPrimitive(Schema.FieldType.UUID, "not-a-uuid");
+    }
+
+    @Test
+    public void testUuidAndBytesCast() {
+        final String uuid = "30000000-0000-0000-0000-000000000001";
+        final ByteBuffer bytes = ByteBuffer.allocate(16)
+                .putLong(UUID.fromString(uuid).getMostSignificantBits())
+                .putLong(UUID.fromString(uuid).getLeastSignificantBits())
+                .flip();
+        final List<Schema.Field> inputFields = List.of(
+                Schema.Field.of("uuidId", Schema.FieldType.UUID),
+                Schema.Field.of("bytesId", Schema.FieldType.BYTES));
+        final JsonArray array = new Gson().fromJson("""
+                [
+                  { "name": "bytesId", "field": "uuidId", "type": "bytes" },
+                  { "name": "uuidId", "field": "bytesId", "type": "uuid" }
+                ]
+                """, JsonArray.class);
+
+        final List<SelectFunction> functions = SelectFunction.of(array, inputFields);
+        final Map<String, Object> results = SelectFunction.apply(
+                functions, Map.of("uuidId", uuid, "bytesId", bytes), Instant.EPOCH);
+        Assert.assertEquals(uuid, results.get("uuidId"));
+        Assert.assertEquals(16, ((ByteBuffer) results.get("bytesId")).remaining());
+        Assert.assertArrayEquals(bytes.array(), ((ByteBuffer) results.get("bytesId")).array());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBytesCastToUuidRejectsInvalidLength() {
+        final List<SelectFunction> functions = SelectFunction.of(
+                new Gson().fromJson("[{ \"name\": \"id\", \"type\": \"uuid\" }]", JsonArray.class),
+                List.of(Schema.Field.of("id", Schema.FieldType.BYTES)));
+        SelectFunction.apply(functions, Map.of("id", ByteBuffer.allocate(15)), Instant.EPOCH);
+    }
 
     @Test
     public void test() {

--- a/src/test/java/com/mercari/solution/util/schema/converter/ElementToJsonConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/schema/converter/ElementToJsonConverterTest.java
@@ -12,6 +12,8 @@ import java.time.LocalTime;
 import java.util.Base64;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+
 public class ElementToJsonConverterTest {
 
     @Test
@@ -21,6 +23,7 @@ public class ElementToJsonConverterTest {
                 .builder()
                 .withField("booleanField", Schema.FieldType.BOOLEAN)
                 .withField("stringField", Schema.FieldType.STRING)
+                .withField("uuidField", Schema.FieldType.UUID)
                 .withField("int32Field", Schema.FieldType.INT32)
                 .withField("int64Field", Schema.FieldType.INT64)
                 .withField("float32Field", Schema.FieldType.FLOAT32)
@@ -40,6 +43,7 @@ public class ElementToJsonConverterTest {
         final MElement element = MElement.builder()
                 .withBool("booleanField", true)
                 .withString("stringField", "abc")
+                .withString("uuidField", "550e8400-e29b-41d4-a716-446655440000")
                 .withInt32("int32Field", 10)
                 .withInt64("int64Field", 10L)
                 .withBytes("bytesField", "OKOKOK".getBytes(StandardCharsets.UTF_8))
@@ -54,6 +58,7 @@ public class ElementToJsonConverterTest {
                 .build();
 
         final JsonObject jsonObject = ElementToJsonConverter.convert(schema, element.asPrimitiveMap());
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", jsonObject.get("uuidField").getAsString());
     }
 
 }

--- a/src/test/java/com/mercari/solution/util/schema/converter/UuidConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/schema/converter/UuidConverterTest.java
@@ -1,0 +1,67 @@
+package com.mercari.solution.util.schema.converter;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.datastore.v1.Entity;
+import com.google.firestore.v1.Document;
+import com.mercari.solution.module.Schema;
+import com.mercari.solution.util.schema.CalciteSchemaUtil;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class UuidConverterTest {
+
+    private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+    private static final Schema SCHEMA = Schema.builder()
+            .withField("id", Schema.FieldType.UUID)
+            .build();
+    private static final Map<String, Object> VALUES = Map.of("id", UUID_VALUE);
+
+    @Test
+    public void testTextInputs() {
+        assertEquals(UUID_VALUE, CsvToElementConverter.convert(SCHEMA.getFields(), UUID_VALUE).get("id"));
+        assertEquals(UUID_VALUE, JsonToElementConverter.convert(
+                SCHEMA.getFields(), "{\"id\":\"" + UUID_VALUE + "\"}").get("id"));
+    }
+
+    @Test
+    public void testRowConversion() {
+        final org.apache.beam.sdk.schemas.Schema rowSchema = ElementToRowConverter.convertSchema(SCHEMA.getFields());
+        assertEquals(org.apache.beam.sdk.schemas.Schema.TypeName.STRING,
+                rowSchema.getField("id").getType().getTypeName());
+
+        final Row row = ElementToRowConverter.convert(rowSchema, VALUES);
+        assertEquals(UUID_VALUE, row.getString("id"));
+    }
+
+    @Test
+    public void testTableRowConversion() {
+        final TableSchema tableSchema = ElementToTableRowConverter.convertSchema(SCHEMA);
+        assertEquals("STRING", tableSchema.getFields().getFirst().getType());
+
+        final TableRow row = ElementToTableRowConverter.convert(SCHEMA, VALUES);
+        assertEquals(UUID_VALUE, row.get("id"));
+    }
+
+    @Test
+    public void testEntityAndDocumentConversion() {
+        final Entity entity = ElementToEntityConverter
+                .convertBuilder(SCHEMA, VALUES, List.of())
+                .build();
+        assertEquals(UUID_VALUE, entity.getPropertiesOrThrow("id").getStringValue());
+
+        final Document document = ElementToDocumentConverter.convertBuilder(SCHEMA, VALUES).build();
+        assertEquals(UUID_VALUE, document.getFieldsOrThrow("id").getStringValue());
+    }
+
+    @Test
+    public void testCalciteConversion() {
+        assertEquals(UUID_VALUE, CalciteSchemaUtil.convertSqlValue(Schema.FieldType.UUID, UUID_VALUE));
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR adds UUID as a logical field type and supports UUID conversion in the `select` transform.

It enables pipelines to preserve Avro UUID logical types and convert UUID values between their canonical string representation and standard 16-byte binary representation.

## Changes

- Add `uuid` to the supported field types.
- Preserve the Avro UUID logical type when converting between Avro and element schemas.
- Support the following casts in the select transform:
  - String to UUID
  - UUID to string
  - UUID to 16-byte binary
  - 16-byte binary to UUID
- Reject invalid UUID strings and byte sequences that are not exactly 16 bytes.
- Support UUID values in existing conversion paths, including:
  - Beam Row
  - BigQuery TableRow
  - Calcite
  - Datastore and Firestore
  - Bigtable
  - Protobuf
  - JSON and CSV
- Document the `uuid` type and UUID/bytes casting behavior.
- _**Native UUID** reads and writes using the Spanner client API are NOT included and should be addressed separately._

## Example

  The following example demonstrates two UUID conversions using PostgreSQL:

  - PostgreSQL `uuid` to `varchar(36)` using `type: string`
  - PostgreSQL `bytea` containing exactly 16 bytes to `uuid` using `type: uuid`

  Type conversion is performed by the `select` transform rather than by the JDBC source query.

  ### PostgreSQL tables

  ```sql
  CREATE TABLE source_uuid_users (
      id   uuid PRIMARY KEY,
      name varchar(255) NOT NULL
  );

  CREATE TABLE source_binary_users (
      id   bytea PRIMARY KEY,
      name varchar(255) NOT NULL,
      CONSTRAINT source_binary_users_id_length CHECK (octet_length(id) = 16)
  );

  CREATE TABLE destination_text_users (
      id   varchar(36) PRIMARY KEY,
      name varchar(255) NOT NULL
  );

  CREATE TABLE destination_uuid_users (
      id   uuid PRIMARY KEY,
      name varchar(255) NOT NULL
  );
  ```

  Example records:

  ```sql
  INSERT INTO source_uuid_users (id, name)
  VALUES (
      '550e8400-e29b-41d4-a716-446655440000',
      'UUID source'
  );

  INSERT INTO source_binary_users (id, name)
  VALUES (
      decode(replace(
          '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
          '-',
          ''
      ), 'hex'),
      'Binary source'
  );
  ```

  ### Pipeline configuration

  ```yaml
  sources:
    - name: ReadUuidUsers
      module: jdbc
      parameters:
        url: jdbc:postgresql://postgres:5432/localdb
        driver: org.postgresql.Driver
        user: pipeline
        password: pipeline
        query: |-
          SELECT
            id,
            name
          FROM source_uuid_users

    - name: ReadBinaryUsers
      module: jdbc
      parameters:
        url: jdbc:postgresql://postgres:5432/localdb
        driver: org.postgresql.Driver
        user: pipeline
        password: pipeline
        query: |-
          SELECT
            id,
            name
          FROM source_binary_users

  transforms:
    - name: ConvertUuidToString
      module: select
      inputs:
        - ReadUuidUsers
      parameters:
        select:
          - name: id
            type: string
          - name: name

    - name: ConvertBytesToUuid
      module: select
      inputs:
        - ReadBinaryUsers
      parameters:
        select:
          - name: id
            type: uuid
          - name: name

  sinks:
    - name: WriteTextUsers
      module: jdbc
      inputs:
        - ConvertUuidToString
      parameters:
        url: jdbc:postgresql://postgres:5432/localdb
        driver: org.postgresql.Driver
        user: pipeline
        password: pipeline
        table: destination_text_users
        op: INSERT_OR_DONOTHING
        keyFields:
          - id

    - name: WriteUuidUsers
      module: jdbc
      inputs:
        - ConvertBytesToUuid
      parameters:
        url: jdbc:postgresql://postgres:5432/localdb
        driver: org.postgresql.Driver
        user: pipeline
        password: pipeline
        table: destination_uuid_users
        op: INSERT_OR_DONOTHING
        keyFields:
          - id
  ```

## Tests

- String, UUID, and 16-byte conversions
- Invalid UUID strings and invalid byte lengths
- Avro UUID logical type preservation
- JSON and CSV input
- Beam Row
- BigQuery TableRow
- Datastore and Firestore
- Calcite

## Local validation

In my local environment, I also manually verified bidirectional data transfers using UUID values stored as:

- PostgreSQL uuid
- PostgreSQL bpchar(36)
- MySQL CHAR(36)
- MySQL BINARY(16)

The setup used for this manual validation is not included in this PR.