### PR TITLE
fix: correct millis-to-micros conversion for Avro timestamp-millis in Document conversion

### DIFF
--- a/src/main/java/com/mercari/solution/util/schema/converter/AvroToDocumentConverter.java
+++ b/src/main/java/com/mercari/solution/util/schema/converter/AvroToDocumentConverter.java
@@ -75,7 +75,7 @@ public class AvroToDocumentConverter {
             case LONG -> {
                 final Long l = (Long) v;
                 if(LogicalTypes.timestampMillis().equals(schema.getLogicalType())) {
-                    yield Value.newBuilder().setTimestampValue(DateTimeUtil.toProtoTimestamp(l/1000L)).build();
+                    yield Value.newBuilder().setTimestampValue(DateTimeUtil.toProtoTimestamp(l * 1000L)).build();
                 } else if(LogicalTypes.timestampMicros().equals(schema.getLogicalType())) {
                     yield Value.newBuilder().setTimestampValue(DateTimeUtil.toProtoTimestamp(l)).build();
                 } else if(LogicalTypes.timeMicros().equals(schema.getLogicalType())) {

--- a/src/test/java/com/mercari/solution/util/schema/converter/AvroToDocumentConverterTest.java
+++ b/src/test/java/com/mercari/solution/util/schema/converter/AvroToDocumentConverterTest.java
@@ -1,0 +1,76 @@
+package com.mercari.solution.util.schema.converter;
+
+import com.google.firestore.v1.Document;
+import com.google.protobuf.Timestamp;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Instant;
+
+public class AvroToDocumentConverterTest {
+
+    private static Schema createTimestampSchema() {
+        final Schema timestampMillisType = LogicalTypes.timestampMillis()
+                .addToSchema(Schema.create(Schema.Type.LONG));
+        final Schema timestampMicrosType = LogicalTypes.timestampMicros()
+                .addToSchema(Schema.create(Schema.Type.LONG));
+        return SchemaBuilder.record("TimestampRecord").fields()
+                .name("timestampMillisField").type(timestampMillisType).noDefault()
+                .name("timestampMicrosField").type(timestampMicrosType).noDefault()
+                .endRecord();
+    }
+
+    @Test
+    public void testTimestampMillisField() {
+        final Instant instant = Instant.parse("2026-08-07T10:15:30.123Z");
+
+        final Schema schema = createTimestampSchema();
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put("timestampMillisField", instant.toEpochMilli());
+        record.put("timestampMicrosField", 0L);
+
+        final Document document = AvroToDocumentConverter.convertBuilder(schema, record).build();
+        final Timestamp actual = document.getFieldsMap().get("timestampMillisField").getTimestampValue();
+
+        Assert.assertEquals(instant.getEpochSecond(), actual.getSeconds());
+        Assert.assertEquals(123_000_000, actual.getNanos());
+    }
+
+    @Test
+    public void testTimestampMicrosField() {
+        final Instant instant = Instant.parse("2026-08-07T10:15:30.123456Z");
+        final long epochMicros = instant.getEpochSecond() * 1000_000L + instant.getNano() / 1000L;
+
+        final Schema schema = createTimestampSchema();
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put("timestampMillisField", 0L);
+        record.put("timestampMicrosField", epochMicros);
+
+        final Document document = AvroToDocumentConverter.convertBuilder(schema, record).build();
+        final Timestamp actual = document.getFieldsMap().get("timestampMicrosField").getTimestampValue();
+
+        Assert.assertEquals(instant.getEpochSecond(), actual.getSeconds());
+        Assert.assertEquals(123_456_000, actual.getNanos());
+    }
+
+    @Test
+    public void testTimestampMillisAndMicrosAgree() {
+        final Instant instant = Instant.parse("2026-08-07T10:15:30.123Z");
+
+        final Schema schema = createTimestampSchema();
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put("timestampMillisField", instant.toEpochMilli());
+        record.put("timestampMicrosField", instant.getEpochSecond() * 1000_000L + instant.getNano() / 1000L);
+
+        final Document document = AvroToDocumentConverter.convertBuilder(schema, record).build();
+
+        Assert.assertEquals(
+                document.getFieldsMap().get("timestampMicrosField").getTimestampValue(),
+                document.getFieldsMap().get("timestampMillisField").getTimestampValue());
+    }
+}


### PR DESCRIPTION
Follow-up to #119, in the Avro → Firestore/Datastore Document path.

## Problem

`DateTimeUtil.toProtoTimestamp(Long)` interprets its argument as **epoch microseconds**:

```java
public static com.google.protobuf.Timestamp toProtoTimestamp(final Long epocMicros) {
    long second = epocMicros / 1000_000L;
    long nano   = epocMicros % 1000_000L * 1000L;
```

`AvroToDocumentConverter` passes it epoch **seconds** on the `timestamp-millis` branch:

```java
if(LogicalTypes.timestampMillis().equals(schema.getLogicalType())) {
    yield ...setTimestampValue(DateTimeUtil.toProtoTimestamp(l/1000L)).build();   // l is epoch millis
} else if(LogicalTypes.timestampMicros().equals(schema.getLogicalType())) {
    yield ...setTimestampValue(DateTimeUtil.toProtoTimestamp(l)).build();         // correct
}
```

The value ends up wrong by a factor of 10^6. `2026-08-07T10:15:30.123Z` (epoch millis `1786097730123`) becomes `1786` seconds — `1970-01-01T00:29:46Z`. Every `timestamp-millis` field written through this path collapses to just after the epoch, silently.

The adjacent `timestamp-micros` branch passing `l` straight through confirms microseconds is the expected unit. Of the call sites of `toProtoTimestamp` outside `DateTimeUtil`, this is the only one that divides.

The path is reachable from `MElement` and `ElementToDocumentConverter`, and `timestamp-millis` is a first-class logical type here (`REQUIRED_LOGICAL_TIMESTAMP_MILLI_TYPE` / `NULLABLE_LOGICAL_TIMESTAMP_MILLI_TYPE`).

## Fix

`l/1000L` → `l * 1000L`, converting millis to the micros the callee expects.

## Tests

Adds `AvroToDocumentConverterTest` with three cases:

| test | before | after |
|---|---|---|
| `testTimestampMillisField` | FAIL — `expected:<1786097730> but was:<1786>` | pass |
| `testTimestampMillisAndMicrosAgree` | FAIL — `expected seconds 1786097730, was 1786` | pass |
| `testTimestampMicrosField` | pass | pass |

`testTimestampMicrosField` passes both before and after by design — it guards the already-correct branch against over-correction.

```
before fix:  Tests run: 3, Failures: 2
after fix:   Tests run: 3, Failures: 0
```

## Note

Building from a clean clone needed `org.apache.kafka:kafka-clients` added locally — Beam ships it at `provided` scope so it is not pulled transitively by `beam-sdks-java-io-kafka` (same thing reported in the second half of #108). That is unrelated to this change and is **not** included here; I only added it locally to run the tests. Happy to open a separate PR if useful.